### PR TITLE
feat: add gas costs for the shapes in stream types section

### DIFF
--- a/docs/concepts/protocol/02-stream-types.mdx
+++ b/docs/concepts/protocol/02-stream-types.mdx
@@ -22,6 +22,12 @@ With this type of stream, the payment rate remains constant, meaning that the sa
 streamed to the recipient every second. This provides greater predictability and is easy to understand because of how
 intuitive it is. Imagine a diagonal line going up and to the right – that's how simple it is.
 
+:::info
+
+The gas cost for this shape is approximately _217,445_ on mainnet. This may vary due to multiple factors.
+
+:::
+
 ### Cliffs
 
 It is possible to attach a "cliff" to a Lockup Linear stream, which sets a cut-off point for releasing assets. Prior to
@@ -82,6 +88,12 @@ Exponentials are a great fit if you are looking to airdrop tokens, because your 
 majority of the tokens towards the end of the stream instead of receiving the tokens all at once (no streaming) or in a
 linear fashion (Lockup Linear). This incentivizes long-term behavior and a constructive attitude.
 
+:::info
+
+The gas cost for this shape is approximately _279,262_ on mainnet. This may vary due to multiple factors.
+
+:::
+
 ### Exponential Cliff
 
 Another use case for Lockup Dynamic is a variation of the previous design: an Exponential Cliff.
@@ -110,6 +122,12 @@ ends, and then the rest of the stream is exponentially streamed.
 This is an excellent distribution if you are a company looking to set up a token vesting plan for your employees. Your
 employees will have an incentive to remain with your company in the long run, as they will receive an increasingly
 larger number of tokens.
+
+:::info
+
+The gas cost for this shape is approximately _331,143_ on mainnet. This may vary due to multiple factors.
+
+:::
 
 ### Unlock in Steps
 
@@ -146,6 +164,13 @@ The advantage of using Unlock in Steps instead of a normal vesting contract is t
 process. No more worries about setting up vesting contracts or creating a user interface for your employees to claim
 their tokens.
 
+:::info
+
+The gas cost for this shape is approximately _462,013_ on mainnet for four unlocks. This may vary as there are multiple
+factors to consider.
+
+:::
+
 ### Monthly Unlocks
 
 Monthly Unlocks is a special case of Unlock in Steps where assets are unlocked on the same day every month, e.g. the 1st
@@ -175,6 +200,13 @@ in Steps, unwithdrawn tokens will carry over to the next period, providing flexi
 This shape is ideal for employers who wish to set up advanced payment schedules for their employees, offering them
 access to funds on a predictable, monthly basis.
 
+:::info
+
+The gas cost for this shape is approximately _878,643_ on mainnet for a period of exactly **one year**. This may vary as
+there are multiple factors to consider.
+
+:::
+
 ### Timelock
 
 The Timelock shape locks all tokens for a specified period. Users cannot access the tokens until the set period elapses.
@@ -200,6 +232,12 @@ The Timelock shape locks all tokens for a specified period. Users cannot access 
 Once the set period elapses, the full amount becomes accessible to the recipient. This setup is particularly
 advantageous for projects seeking to stabilize token pricing and minimize market volatility, encouraging investors to
 maintain their stake over a more extended period.
+
+:::info
+
+The gas cost for this shape is approximately _305,265_ on mainnet. This may vary due to multiple factors.
+
+:::
 
 ### Unlock Linear
 
@@ -231,6 +269,12 @@ contract term — this is your "salary".
 Another use case is a token distribution to investors where a particular amount gets unlocked immediately followed by a
 linear vesting plan.
 
+:::info
+
+The gas cost for this shape is approximately _305,235_ on mainnet. This may vary due to multiple factors.
+
+:::
+
 ### Unlock Cliff
 
 This shape is useful for companies who want to distribute tokens to their investors using a cliff followed by linear
@@ -258,3 +302,9 @@ vesting but also want to unlock some liquidity at the beginning to be able to al
 
 Initially, a set amount of tokens are made available to the recipient as an upfront payment. After this initial unlock,
 the tokens are held during the cliff period until the moment of time set. The release resumes in a linearly post-cliff.
+
+:::info
+
+The gas cost for this shape is approximately _331,178_ on mainnet. This may vary due to multiple factors.
+
+:::

--- a/docs/concepts/protocol/02-stream-types.mdx
+++ b/docs/concepts/protocol/02-stream-types.mdx
@@ -11,6 +11,13 @@ import FunctionPlot from "@site/src/components/FunctionPlot";
 "Lockup" is a higher-level category that refers to the requirement that the creator of a stream must lock up a certain
 amount of assets in a smart contract. All streams currently supported by Sablier are Lockup streams.
 
+:::note
+
+The gas estimation for the shapes can be found at
+[this branch](https://github.com/sablier-labs/examples/tree/shapes-benchmark).
+
+:::
+
 ## Lockup Linear
 
 Lockup Linear streams are the simplest type of stream in Sablier. The streamed amount over time follows a straight line
@@ -24,7 +31,7 @@ intuitive it is. Imagine a diagonal line going up and to the right – that's ho
 
 :::info
 
-The gas cost for this shape is approximately _217,445_ on mainnet. This may vary due to multiple factors.
+The gas cost for this shape is approximately _152,019_ on Mainnet. This may vary due to multiple factors.
 
 :::
 
@@ -56,6 +63,12 @@ This feature is especially useful for vesting ERC-20 assets as it allows you to 
 then 3 additional years of linear streaming. If the stream is for an employee, you can make it cancellable so that if
 the employee leaves your company during the stream, you can cancel it and recover the assets that have not yet been
 streamed.
+
+:::info
+
+The gas cost for this shape is approximately _152,019_ on Mainnet. This may vary due to multiple factors.
+
+:::
 
 ## Lockup Dynamic
 
@@ -90,7 +103,7 @@ linear fashion (Lockup Linear). This incentivizes long-term behavior and a const
 
 :::info
 
-The gas cost for this shape is approximately _279,262_ on mainnet. This may vary due to multiple factors.
+The gas cost for this shape is approximately _213,610_ on Mainnet. This may vary due to multiple factors.
 
 :::
 
@@ -125,7 +138,7 @@ larger number of tokens.
 
 :::info
 
-The gas cost for this shape is approximately _331,143_ on mainnet. This may vary due to multiple factors.
+The gas cost for this shape is approximately _264,854_ on Mainnet. This may vary due to multiple factors.
 
 :::
 
@@ -166,7 +179,7 @@ their tokens.
 
 :::info
 
-The gas cost for this shape is approximately _462,013_ on mainnet for four unlocks. This may vary as there are multiple
+The gas cost for this shape is approximately _392,982_ on Mainnet for four unlocks. This may vary as there are multiple
 factors to consider.
 
 :::
@@ -202,7 +215,7 @@ access to funds on a predictable, monthly basis.
 
 :::info
 
-The gas cost for this shape is approximately _878,643_ on mainnet for a period of exactly **one year**. This may vary as
+The gas cost for this shape is approximately _803,150_ on Mainnet for a period of exactly **one year**. This may vary as
 there are multiple factors to consider.
 
 :::
@@ -235,7 +248,7 @@ maintain their stake over a more extended period.
 
 :::info
 
-The gas cost for this shape is approximately _305,265_ on mainnet. This may vary due to multiple factors.
+The gas cost for this shape is approximately _239,232_ on Mainnet. This may vary due to multiple factors.
 
 :::
 
@@ -271,7 +284,7 @@ linear vesting plan.
 
 :::info
 
-The gas cost for this shape is approximately _305,235_ on mainnet. This may vary due to multiple factors.
+The gas cost for this shape is approximately _239,232_ on Mainnet. This may vary due to multiple factors.
 
 :::
 
@@ -305,6 +318,6 @@ the tokens are held during the cliff period until the moment of time set. The re
 
 :::info
 
-The gas cost for this shape is approximately _331,178_ on mainnet. This may vary due to multiple factors.
+The gas cost for this shape is approximately _290,477_ on Mainnet. This may vary due to multiple factors.
 
 :::


### PR DESCRIPTION
Couldn't find a better place to put this gas costs.

Also, I want to mention that these may not be accurate with how much the end user will pay when using the app, as it uses the `batch` contract to create single streams. 

Also explained in this PR: https://github.com/sablier-labs/examples/pull/30