### PR TITLE
fix: invalid link to go to next page for subsections in contracts guides

### DIFF
--- a/docs/contracts/v2/guides/batch-create-streams/_category_.json
+++ b/docs/contracts/v2/guides/batch-create-streams/_category_.json
@@ -1,8 +1,5 @@
 {
   "collapsed": true,
   "label": "Batch Create Streams",
-  "link": {
-    "id": "batch-create-streams"
-  },
   "position": 3
 }

--- a/docs/contracts/v2/guides/create-stream/_category_.json
+++ b/docs/contracts/v2/guides/create-stream/_category_.json
@@ -1,8 +1,5 @@
 {
   "collapsed": true,
   "label": "Create a Stream",
-  "link": {
-    "id": "create-stream"
-  },
   "position": 2
 }


### PR DESCRIPTION
While studying this excellent documentation, I noticed that it is impossible to make following transitions by clicking `Next`:
- https://docs.sablier.com/contracts/v2/guides/local-environment => https://docs.sablier.com/contracts/v2/guides/create-stream/lockup-linear
- https://docs.sablier.com/contracts/v2/guides/create-stream/lockup-dynamic => https://docs.sablier.com/contracts/v2/guides/batch-create-streams/batch-linear-streams

As far as I understand, since the name of the subsection corresponds to the link `id` specified in the `_category_.json`, this `id` can be removed, which solved the problem of moving to the next existent page.