### PR TITLE
fix: invalid link for stream creator test

### DIFF
--- a/docs/contracts/v2/guides/01-local-environment.md
+++ b/docs/contracts/v2/guides/01-local-environment.md
@@ -156,9 +156,10 @@ $ forge test
 If the test passed, you should see a message like this:
 
 ```text
-Running 1 test for test/StreamCreator.t.sol:StreamCreatorTest
-[PASS] test_CreateStream() (gas: { gasValue })
-Test result: ok. 1 passed; 0 failed; finished in { time }
+Ran 2 tests for v2/core/LockupStreamCreator.t.sol:LockupStreamCreatorTest
+[PASS] test_LockupDynamicStreamCreator() (gas: 273719)
+[PASS] test_LockupLinearStreamCreator() (gas: 186388)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 6.34s (5.80s CPU time)
 ```
 
 ## Next steps

--- a/docs/contracts/v2/guides/01-local-environment.md
+++ b/docs/contracts/v2/guides/01-local-environment.md
@@ -144,7 +144,7 @@ As a prerequisite, you will need an RPC that supports forking. A good solution f
 Once you have obtained your RPC, you can proceed to run the following test:
 
 ```solidity reference title="Stream Creator Test"
-https://github.com/sablier-labs/examples/blob/main/v2/core/LockupLinearStreamCreator.t.sol
+https://github.com/sablier-labs/examples/blob/main/v2/core/LockupStreamCreator.t.sol
 ```
 
 You can run the test using Forge:


### PR DESCRIPTION
In the PR https://github.com/sablier-labs/examples/pull/20, the [test](https://github.com/sablier-labs/examples/blob/c73ec1d13b5d1756d775679729a9f180d2031c8a/v2/core/LockupLinearStreamCreator.t.sol) referenced in the [documentation](https://docs.sablier.com/contracts/v2/guides/local-environment#run-a-fork-test) was removed and a [new one](https://github.com/sablier-labs/examples/blob/5def4951adbdf3c3f5131f59afcd4f334e0cb759/v2/core/LockupStreamCreator.t.sol) was created.