### PR TITLE
fix: invalid link to stream example

### DIFF
--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -1,7 +1,7 @@
 export const links = {
   app: "https://app.sablier.com",
   discord: "https://discord.gg/bSwRCwWRsT",
-  example: "https://app.sablier.com/stream/LL-50-40",
+  example: "https://app.sablier.com/stream/LL2-11155111-3/",
   forms: {
     integrations: "https://forms.gle/KKDo1aMGp2b2tdEr5",
   },


### PR DESCRIPTION
In the section https://docs.sablier.com/concepts/use-cases#3-transparency the link [`here`](https://app.sablier.com/stream/LL-50-40/) leads to a stream that no longer exists