### PR TITLE
style: add benchmark table formatter

### DIFF
--- a/docs/contracts/v2/05-gas-benchmarks.md
+++ b/docs/contracts/v2/05-gas-benchmarks.md
@@ -22,85 +22,85 @@ view the code that generates these benchmarks.
 
 | Function                                                    | Gas Usage |
 | ----------------------------------------------------------- | --------- |
-| `burn`                                                      | 15694     |
-| `cancel`                                                    | 56829     |
-| `renounce`                                                  | 19381     |
-| `createWithDurations` (Broker fee set) (cliff not set)      | 129276    |
-| `createWithDurations` (Broker fee not set) (cliff not set)  | 113680    |
-| `createWithDurations` (Broker fee set) (cliff set)          | 138071    |
-| `createWithDurations` (Broker fee not set) (cliff set)      | 133273    |
-| `createWithTimestamps` (Broker fee set) (cliff not set)     | 115334    |
-| `createWithTimestamps` (Broker fee not set) (cliff not set) | 110530    |
-| `createWithTimestamps` (Broker fee set) (cliff set)         | 137629    |
-| `createWithTimestamps` (Broker fee not set) (cliff set)     | 132827    |
-| `withdraw` (After End Time) (by Recipient)                  | 29701     |
-| `withdraw` (Before End Time) (by Recipient)                 | 19104     |
-| `withdraw` (After End Time) (by Anyone)                     | 24799     |
-| `withdraw` (Before End Time) (by Anyone)                    | 19002     |
+| `burn`                                                      | 15,694     |
+| `cancel`                                                    | 56,829     |
+| `renounce`                                                  | 19,381     |
+| `createWithDurations` (Broker fee set) (cliff not set)      | 129,276    |
+| `createWithDurations` (Broker fee not set) (cliff not set)  | 113,680    |
+| `createWithDurations` (Broker fee set) (cliff set)          | 138,071    |
+| `createWithDurations` (Broker fee not set) (cliff set)      | 133,273    |
+| `createWithTimestamps` (Broker fee set) (cliff not set)     | 115,334    |
+| `createWithTimestamps` (Broker fee not set) (cliff not set) | 110,530    |
+| `createWithTimestamps` (Broker fee set) (cliff set)         | 137,629    |
+| `createWithTimestamps` (Broker fee not set) (cliff set)     | 132,827    |
+| `withdraw` (After End Time) (by Recipient)                  | 29,701     |
+| `withdraw` (Before End Time) (by Recipient)                 | 19,104     |
+| `withdraw` (After End Time) (by Anyone)                     | 24,799     |
+| `withdraw` (Before End Time) (by Anyone)                    | 19,002     |
 
 ### Lockup Dynamic
 
 | Function                                                   | Gas Usage |
 | ---------------------------------------------------------- | --------- |
-| `burn`                                                     | 15716     |
-| `cancel`                                                   | 74341     |
-| `renounce`                                                 | 39007     |
-| `createWithDurations` (2 segments) (Broker fee set)        | 200602    |
-| `createWithDurations` (2 segments) (Broker fee not set)    | 185037    |
-| `createWithTimestamps` (2 segments) (Broker fee set)       | 184780    |
-| `createWithTimestamps` (2 segments) (Broker fee not set)   | 180015    |
-| `withdraw` (2 segments) (After End Time) (by Recipient)    | 19108     |
-| `withdraw` (2 segments) (Before End Time) (by Recipient)   | 27554     |
-| `withdraw` (2 segments) (After End Time) (by Anyone)       | 14239     |
-| `withdraw` (2 segments) (Before End Time) (by Anyone)      | 27485     |
-| `createWithDurations` (10 segments) (Broker fee set)       | 395084    |
-| `createWithDurations` (10 segments) (Broker fee not set)   | 390326    |
-| `createWithTimestamps` (10 segments) (Broker fee set)      | 385125    |
-| `createWithTimestamps` (10 segments) (Broker fee not set)  | 380375    |
-| `withdraw` (10 segments) (After End Time) (by Recipient)   | 14295     |
-| `withdraw` (10 segments) (Before End Time) (by Recipient)  | 32545     |
-| `withdraw` (10 segments) (After End Time) (by Anyone)      | 14246     |
-| `withdraw` (10 segments) (Before End Time) (by Anyone)     | 32476     |
-| `createWithDurations` (100 segments) (Broker fee set)      | 2740781   |
-| `createWithDurations` (100 segments) (Broker fee not set)  | 2736987   |
-| `createWithTimestamps` (100 segments) (Broker fee set)     | 2642946   |
-| `createWithTimestamps` (100 segments) (Broker fee not set) | 2639185   |
-| `withdraw` (100 segments) (After End Time) (by Recipient)  | 14295     |
-| `withdraw` (100 segments) (Before End Time) (by Recipient) | 88968     |
-| `withdraw` (100 segments) (After End Time) (by Anyone)     | 14226     |
-| `withdraw` (100 segments) (Before End Time) (by Anyone)    | 88899     |
+| `burn`                                                     | 15,716     |
+| `cancel`                                                   | 74,341     |
+| `renounce`                                                 | 39,007     |
+| `createWithDurations` (2 segments) (Broker fee set)        | 200,602    |
+| `createWithDurations` (2 segments) (Broker fee not set)    | 185,037    |
+| `createWithTimestamps` (2 segments) (Broker fee set)       | 184,780    |
+| `createWithTimestamps` (2 segments) (Broker fee not set)   | 180,015    |
+| `withdraw` (2 segments) (After End Time) (by Recipient)    | 19,108     |
+| `withdraw` (2 segments) (Before End Time) (by Recipient)   | 27,554     |
+| `withdraw` (2 segments) (After End Time) (by Anyone)       | 14,239     |
+| `withdraw` (2 segments) (Before End Time) (by Anyone)      | 27,485     |
+| `createWithDurations` (10 segments) (Broker fee set)       | 395,084    |
+| `createWithDurations` (10 segments) (Broker fee not set)   | 390,326    |
+| `createWithTimestamps` (10 segments) (Broker fee set)      | 385,125    |
+| `createWithTimestamps` (10 segments) (Broker fee not set)  | 380,375    |
+| `withdraw` (10 segments) (After End Time) (by Recipient)   | 14,295     |
+| `withdraw` (10 segments) (Before End Time) (by Recipient)  | 32,545     |
+| `withdraw` (10 segments) (After End Time) (by Anyone)      | 14,246     |
+| `withdraw` (10 segments) (Before End Time) (by Anyone)     | 32,476     |
+| `createWithDurations` (100 segments) (Broker fee set)      | 2,740,781   |
+| `createWithDurations` (100 segments) (Broker fee not set)  | 2,736,987   |
+| `createWithTimestamps` (100 segments) (Broker fee set)     | 2,642,946   |
+| `createWithTimestamps` (100 segments) (Broker fee not set) | 2,639,185   |
+| `withdraw` (100 segments) (After End Time) (by Recipient)  | 14,295     |
+| `withdraw` (100 segments) (Before End Time) (by Recipient) | 88,968     |
+| `withdraw` (100 segments) (After End Time) (by Anyone)     | 14,226     |
+| `withdraw` (100 segments) (Before End Time) (by Anyone)    | 88,899     |
 
 ### Lockup Tranched
 
 | Function                                                   | Gas Usage |
 | ---------------------------------------------------------- | --------- |
-| `burn`                                                     | 15738     |
-| `cancel`                                                   | 63994     |
-| `renounce`                                                 | 26501     |
-| `createWithDurations` (2 tranches) (Broker fee set)        | 199536    |
-| `createWithDurations` (2 tranches) (Broker fee not set)    | 183969    |
-| `createWithTimestamps` (2 tranches) (Broker fee set)       | 189410    |
-| `createWithTimestamps` (2 tranches) (Broker fee not set)   | 183945    |
-| `withdraw` (2 tranches) (After End Time) (by Recipient)    | 20100     |
-| `withdraw` (2 tranches) (Before End Time) (by Recipient)   | 14797     |
-| `withdraw` (2 tranches) (After End Time) (by Anyone)       | 15199     |
-| `withdraw` (2 tranches) (Before End Time) (by Anyone)      | 14695     |
-| `createWithDurations` (10 tranches) (Broker fee set)       | 388757    |
-| `createWithDurations` (10 tranches) (Broker fee not set)   | 383998    |
-| `createWithTimestamps` (10 tranches) (Broker fee set)      | 397102    |
-| `createWithTimestamps` (10 tranches) (Broker fee not set)  | 391750    |
-| `withdraw` (10 tranches) (After End Time) (by Recipient)   | 17855     |
-| `withdraw` (10 tranches) (Before End Time) (by Recipient)  | 19616     |
-| `withdraw` (10 tranches) (After End Time) (by Anyone)      | 17760     |
-| `withdraw` (10 tranches) (Before End Time) (by Anyone)     | 19514     |
-| `createWithDurations` (100 tranches) (Broker fee set)      | 2672918   |
-| `createWithDurations` (100 tranches) (Broker fee not set)  | 2668643   |
-| `createWithTimestamps` (100 tranches) (Broker fee set)     | 2738297   |
-| `createWithTimestamps` (100 tranches) (Broker fee not set) | 2734635   |
-| `withdraw` (100 tranches) (After End Time) (by Recipient)  | 46746     |
-| `withdraw` (100 tranches) (Before End Time) (by Recipient) | 73989     |
-| `withdraw` (100 tranches) (After End Time) (by Anyone)     | 46644     |
-| `withdraw` (100 tranches) (Before End Time) (by Anyone)    | 73887     |
+| `burn`                                                     | 15,738     |
+| `cancel`                                                   | 63,994     |
+| `renounce`                                                 | 26,501     |
+| `createWithDurations` (2 tranches) (Broker fee set)        | 199,536    |
+| `createWithDurations` (2 tranches) (Broker fee not set)    | 183,969    |
+| `createWithTimestamps` (2 tranches) (Broker fee set)       | 189,410    |
+| `createWithTimestamps` (2 tranches) (Broker fee not set)   | 183,945    |
+| `withdraw` (2 tranches) (After End Time) (by Recipient)    | 20,100     |
+| `withdraw` (2 tranches) (Before End Time) (by Recipient)   | 14,797     |
+| `withdraw` (2 tranches) (After End Time) (by Anyone)       | 15,199     |
+| `withdraw` (2 tranches) (Before End Time) (by Anyone)      | 14,695     |
+| `createWithDurations` (10 tranches) (Broker fee set)       | 388,757    |
+| `createWithDurations` (10 tranches) (Broker fee not set)   | 383,998    |
+| `createWithTimestamps` (10 tranches) (Broker fee set)      | 397,102    |
+| `createWithTimestamps` (10 tranches) (Broker fee not set)  | 391,750    |
+| `withdraw` (10 tranches) (After End Time) (by Recipient)   | 17,855     |
+| `withdraw` (10 tranches) (Before End Time) (by Recipient)  | 19,616     |
+| `withdraw` (10 tranches) (After End Time) (by Anyone)      | 17,760     |
+| `withdraw` (10 tranches) (Before End Time) (by Anyone)     | 19,514     |
+| `createWithDurations` (100 tranches) (Broker fee set)      | 2,672,918   |
+| `createWithDurations` (100 tranches) (Broker fee not set)  | 2,668,643   |
+| `createWithTimestamps` (100 tranches) (Broker fee set)     | 2,738,297   |
+| `createWithTimestamps` (100 tranches) (Broker fee not set) | 2,734,635   |
+| `withdraw` (100 tranches) (After End Time) (by Recipient)  | 46,746     |
+| `withdraw` (100 tranches) (Before End Time) (by Recipient) | 73,989     |
+| `withdraw` (100 tranches) (After End Time) (by Anyone)     | 46,644     |
+| `withdraw` (100 tranches) (Before End Time) (by Anyone)    | 73,887     |
 
 ## V2 Periphery
 
@@ -116,33 +116,33 @@ to view the code that generates these benchmarks.
 
 | Function                 | Lockup Type     | Segments/Tranches | Batch Size | Gas Usage |
 | ------------------------ | --------------- | ----------------- | ---------- | --------- |
-| `createWithDurationsLL`  | Lockup Linear   | N/A               | 5          | 771013    |
-| `createWithTimestampsLL` | Lockup Linear   | N/A               | 5          | 732772    |
-| `createWithDurationsLD`  | Lockup Dynamic  | 24                | 5          | 3951599   |
-| `createWithTimestampsLD` | Lockup Dynamic  | 24                | 5          | 3815274   |
-| `createWithDurationsLT`  | Lockup Tranched | 24                | 5          | 3862651   |
-| `createWithTimestampsLT` | Lockup Tranched | 24                | 5          | 3744523   |
-| `createWithDurationsLL`  | Lockup Linear   | N/A               | 10         | 1417180   |
-| `createWithTimestampsLL` | Lockup Linear   | N/A               | 10         | 1414247   |
-| `createWithDurationsLD`  | Lockup Dynamic  | 24                | 10         | 7819165   |
-| `createWithTimestampsLD` | Lockup Dynamic  | 24                | 10         | 7585616   |
-| `createWithDurationsLT`  | Lockup Tranched | 24                | 10         | 7632114   |
-| `createWithTimestampsLT` | Lockup Tranched | 24                | 10         | 7444115   |
-| `createWithDurationsLL`  | Lockup Linear   | N/A               | 20         | 2783510   |
-| `createWithTimestampsLL` | Lockup Linear   | N/A               | 20         | 2779081   |
-| `createWithDurationsLD`  | Lockup Dynamic  | 24                | 20         | 15617207  |
-| `createWithTimestampsLD` | Lockup Dynamic  | 24                | 20         | 15131248  |
-| `createWithDurationsLT`  | Lockup Tranched | 24                | 20         | 15211892  |
-| `createWithTimestampsLT` | Lockup Tranched | 24                | 20         | 14846363  |
-| `createWithDurationsLL`  | Lockup Linear   | N/A               | 30         | 4143337   |
-| `createWithTimestampsLL` | Lockup Linear   | N/A               | 30         | 4148585   |
-| `createWithDurationsLD`  | Lockup Dynamic  | 24                | 30         | 23460912  |
-| `createWithTimestampsLD` | Lockup Dynamic  | 24                | 30         | 22697560  |
-| `createWithDurationsLT`  | Lockup Tranched | 24                | 30         | 22794686  |
-| `createWithTimestampsLT` | Lockup Tranched | 24                | 30         | 22267335  |
-| `createWithDurationsLL`  | Lockup Linear   | N/A               | 50         | 6871104   |
-| `createWithTimestampsLL` | Lockup Linear   | N/A               | 50         | 6893797   |
-| `createWithDurationsLD`  | Lockup Dynamic  | 12                | 50         | 22990726  |
-| `createWithTimestampsLD` | Lockup Dynamic  | 12                | 50         | 22355943  |
-| `createWithDurationsLT`  | Lockup Tranched | 12                | 50         | 22413554  |
-| `createWithTimestampsLT` | Lockup Tranched | 12                | 50         | 22006169  |
+| `createWithDurationsLL`  | Lockup Linear   | N/A               | 5          | 771,013    |
+| `createWithTimestampsLL` | Lockup Linear   | N/A               | 5          | 732,772    |
+| `createWithDurationsLD`  | Lockup Dynamic  | 24                | 5          | 3,951,599   |
+| `createWithTimestampsLD` | Lockup Dynamic  | 24                | 5          | 3,815,274   |
+| `createWithDurationsLT`  | Lockup Tranched | 24                | 5          | 3,862,651   |
+| `createWithTimestampsLT` | Lockup Tranched | 24                | 5          | 3,744,523   |
+| `createWithDurationsLL`  | Lockup Linear   | N/A               | 10         | 1,417,180   |
+| `createWithTimestampsLL` | Lockup Linear   | N/A               | 10         | 1,414,247   |
+| `createWithDurationsLD`  | Lockup Dynamic  | 24                | 10         | 7,819,165   |
+| `createWithTimestampsLD` | Lockup Dynamic  | 24                | 10         | 7,585,616   |
+| `createWithDurationsLT`  | Lockup Tranched | 24                | 10         | 7,632,114   |
+| `createWithTimestampsLT` | Lockup Tranched | 24                | 10         | 7,444,115   |
+| `createWithDurationsLL`  | Lockup Linear   | N/A               | 20         | 2,783,510   |
+| `createWithTimestampsLL` | Lockup Linear   | N/A               | 20         | 2,779,081   |
+| `createWithDurationsLD`  | Lockup Dynamic  | 24                | 20         | 15,617,207  |
+| `createWithTimestampsLD` | Lockup Dynamic  | 24                | 20         | 15,131,248  |
+| `createWithDurationsLT`  | Lockup Tranched | 24                | 20         | 15,211,892  |
+| `createWithTimestampsLT` | Lockup Tranched | 24                | 20         | 14,846,363  |
+| `createWithDurationsLL`  | Lockup Linear   | N/A               | 30         | 4,143,337   |
+| `createWithTimestampsLL` | Lockup Linear   | N/A               | 30         | 4,148,585   |
+| `createWithDurationsLD`  | Lockup Dynamic  | 24                | 30         | 23,460,912  |
+| `createWithTimestampsLD` | Lockup Dynamic  | 24                | 30         | 22,697,560  |
+| `createWithDurationsLT`  | Lockup Tranched | 24                | 30         | 22,794,686  |
+| `createWithTimestampsLT` | Lockup Tranched | 24                | 30         | 22,267,335  |
+| `createWithDurationsLL`  | Lockup Linear   | N/A               | 50         | 6,871,104   |
+| `createWithTimestampsLL` | Lockup Linear   | N/A               | 50         | 6,893,797   |
+| `createWithDurationsLD`  | Lockup Dynamic  | 12                | 50         | 22,990,726  |
+| `createWithTimestampsLD` | Lockup Dynamic  | 12                | 50         | 22,355,943  |
+| `createWithDurationsLT`  | Lockup Tranched | 12                | 50         | 22,413,554  |
+| `createWithTimestampsLT` | Lockup Tranched | 12                | 50         | 22,006,169  |

--- a/formatter.js
+++ b/formatter.js
@@ -1,0 +1,12 @@
+import fs from 'fs/promises';
+
+async function formatGasBenchmark() {
+  const filePath = 'docs/contracts/v2/05-gas-benchmarks.md';
+  const markdownContent = await fs.readFile(filePath, 'utf8');
+  const formattedContent = markdownContent.replace(/\b\d+\b/g, (match) => {
+    return parseInt(match).toLocaleString('en-US');
+  });
+  await fs.writeFile(filePath, formattedContent);
+}
+
+formatGasBenchmark();

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "deploy": "docusaurus deploy",
     "fix": "bun run prettier:write && bun run lint:fix",
     "lint:check": "bun eslint . --ext md,mdx,ts,tsx",
-    "lint:fix": "bun eslint . --ext md,mdx,ts,tsx --fix",
+    "lint:fix": "bun eslint . --ext md,mdx,ts,tsx --fix && bun formatter.js",
     "prettier:check": "prettier --check \"**/*.{json,md,mdx,ts,tsx,yml}\"",
     "prettier:write": "prettier --write \"**/*.{json,md,mdx,ts,tsx,yml}\"",
     "serve": "docusaurus serve",


### PR DESCRIPTION
Now that benchmark table is manually added to the docs, I have added a formatter code to format numbers to use xxx,xxx,xxx number format.