### PR TITLE
change typo in  docs/docs/concepts/protocol/08-fees.mdx

### DIFF
--- a/docs/concepts/protocol/08-fees.mdx
+++ b/docs/concepts/protocol/08-fees.mdx
@@ -8,7 +8,7 @@ import Link from "@docusaurus/Link";
 import { links } from "@site/src/constants";
 
 The Sablier Protocol is entirely free to use. There is no protocol fee. However, external integrators who manage their
-own UI may charge broker free in exchange for providing their services. Broker fees can only be charged when a stream is
+own UI may charge broker fee in exchange for providing their services. Broker fees can only be charged when a stream is
 created, and is capped at 10%.
 
 ## Broker fees


### PR DESCRIPTION
There's a jarring typo in the fees docs that can be found here => https://docs.sablier.com/concepts/protocol/fees 

The docs have the following typo "The Sablier Protocol is entirely free to use. There is no protocol fee. However, external integrators who manage their own UI may charge broker `free` in exchange for providing their services".

 It should be  `broker fee` instead of `broker free`. I fixed that typo.