### PR TITLE
feat: add flow deployments addresses

### DIFF
--- a/docs/guides/flow/02-deployments.md
+++ b/docs/guides/flow/02-deployments.md
@@ -22,8 +22,235 @@ Sablier repositories on Github.
 
 ## Mainnets
 
-Coming soon.
+### Ethereum Mainnet
+
+| Contract          | Address                                                                                                               | Deployment                                                                     |
+| :---------------- | :-------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x2d9221a63e12aa796619cb381ec4a71b201281f5](https://etherscan.io/address/0x2d9221a63e12aa796619cb381ec4a71b201281f5) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xb69b27073fa0366cddf432f5976c34c9baf7eae6](https://etherscan.io/address/0xb69b27073fa0366cddf432f5976c34c9baf7eae6) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Arbitrum One
+
+| Contract          | Address                                                                                                              | Deployment                                                                     |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x18a12a7035aa56240bcd236bc019aa245dcc015a](https://arbiscan.io/address/0x18a12a7035aa56240bcd236bc019aa245dcc015a) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x900ebdb9ecfb19f9463d68d1fd6e5fa7ab9c6897](https://arbiscan.io/address/0x900ebdb9ecfb19f9463d68d1fd6e5fa7ab9c6897) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Avalanche
+
+| Contract          | Address                                                                                                               | Deployment                                                                     |
+| :---------------- | :-------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x8c172e42c06302e3cfe555dc4d6b71a756ee186b](https://snowtrace.io/address/0x8c172e42c06302e3cfe555dc4d6b71a756ee186b) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x82ea83ab59b106c125168492cd468c322bd0d195](https://snowtrace.io/address/0x82ea83ab59b106c125168492cd468c322bd0d195) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Base
+
+| Contract          | Address                                                                                                               | Deployment                                                                     |
+| :---------------- | :-------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x1a9adc0e2114c8407cc31669baafeee031d15dd2](https://basescan.org/address/0x1a9adc0e2114c8407cc31669baafeee031d15dd2) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x8e64f389a4697e004647162ec6ea0a7779d5d899](https://basescan.org/address/0x8e64f389a4697e004647162ec6ea0a7779d5d899) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Blast
+
+| Contract          | Address                                                                                                               | Deployment                                                                     |
+| :---------------- | :-------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0xfdac2799644141856e20e021ac06f231cafc731f](https://blastscan.io/address/0xfdac2799644141856e20e021ac06f231cafc731f) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xb40624ce2af67227529f713bac46e2b7064b7b92](https://blastscan.io/address/0xb40624ce2af67227529f713bac46e2b7064b7b92) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### BNB Smart Chain
+
+| Contract          | Address                                                                                                              | Deployment                                                                     |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0xfce01f79247cf450062545e7155d7bd568551d0e](https://bscscan.com/address/0xfce01f79247cf450062545e7155d7bd568551d0e) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xbc6fdd3f59900b9fcd445f8df159e2e794f098ec](https://bscscan.com/address/0xbc6fdd3f59900b9fcd445f8df159e2e794f098ec) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Core Dao
+
+| Contract          | Address                                                                                                                   | Deployment                                                                     |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x447c6ea25540611541ff98fc677ca865f4e92450](https://scan.coredao.org/address/0x447c6ea25540611541ff98fc677ca865f4e92450) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xbfaa055ecfe503e1323dc9fc26b7d3aa3bf54364](https://scan.coredao.org/address/0xbfaa055ecfe503e1323dc9fc26b7d3aa3bf54364) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Gnosis
+
+| Contract          | Address                                                                                                                | Deployment                                                                     |
+| :---------------- | :--------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x5515f774a4db42820802333ba575f68a6e85bd13](https://gnosisscan.io/address/0x5515f774a4db42820802333ba575f68a6e85bd13) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xc07c1128c19c2bf303b68ae061eff5293927630e](https://gnosisscan.io/address/0xc07c1128c19c2bf303b68ae061eff5293927630e) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### IoTex
+
+| Contract          | Address                                                                                                               | Deployment                                                                     |
+| :---------------- | :-------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x1DdC1c21CD39c2Fa16366E6036c95342A31831Ba](https://iotexscan.io/address/0x1DdC1c21CD39c2Fa16366E6036c95342A31831Ba) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x83Dd52FCA44E069020b58155b761A590F12B59d3](https://iotexscan.io/address/0x83Dd52FCA44E069020b58155b761A590F12B59d3) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Lightlink
+
+| Contract          | Address                                                                                                                       | Deployment                                                                     |
+| :---------------- | :---------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x46fa0164c5af9382d330e5a245a2ca8a18398950](https://phoenix.lightlink.io/address/0x46fa0164c5af9382d330e5a245a2ca8a18398950) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xa2a48b83b6c96e1536336df9ead024d557a97a23](https://phoenix.lightlink.io/address/0xa2a48b83b6c96e1536336df9ead024d557a97a23) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Linea
+
+| Contract          | Address                                                                                                                  | Deployment                                                                     |
+| :---------------- | :----------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x949bFa08f1632432A2656a9dB17CA34d54Da8296](https://lineascan.build/address/0x949bFa08f1632432A2656a9dB17CA34d54Da8296) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xF430f0d2f798c42fDFAc35b5e32BD4f63Bf51130](https://lineascan.build/address/0xF430f0d2f798c42fDFAc35b5e32BD4f63Bf51130) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Meld
+
+| Contract          | Address                                                                                                              | Deployment                                                                     |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x9efc8663cab0e2d97ad17c9fbfc8392445517e94](https://meldscan.io/address/0x9efc8663cab0e2d97ad17c9fbfc8392445517e94) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x3d664b2da905ddd0db931982fd9a759ea950d6e1](https://meldscan.io/address/0x3d664b2da905ddd0db931982fd9a759ea950d6e1) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Mode
+
+| Contract          | Address                                                                                                                        | Deployment                                                                     |
+| :---------------- | :----------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x75970dde488431fc4961494569def3269f20d6b3](https://explorer.mode.network/address/0x75970dde488431fc4961494569def3269f20d6b3) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x46fa0164c5af9382d330e5a245a2ca8a18398950](https://explorer.mode.network/address/0x46fa0164c5af9382d330e5a245a2ca8a18398950) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Morph
+
+| Contract          | Address                                                                                                                      | Deployment                                                                     |
+| :---------------- | :--------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0xfe6972d0ae797fae343e5a58d0c7d8513937f092](https://explorer.morphl2.io/address/0xfe6972d0ae797fae343e5a58d0c7d8513937f092) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xab281bbc2bc34a1f202ddff17ffd1c00edf73f3a](https://explorer.morphl2.io/address/0xab281bbc2bc34a1f202ddff17ffd1c00edf73f3a) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Optimism
+
+| Contract          | Address                                                                                                                          | Deployment                                                                     |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x906356e4e6410ea0a97dbc5b071cf394ab0dcd69](https://optimistic.etherscan.io/address/0x906356e4e6410ea0a97dbc5b071cf394ab0dcd69) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xe674fb603d6f72b88bf297c1ba69f57b588a8f6d](https://optimistic.etherscan.io/address/0xe674fb603d6f72b88bf297c1ba69f57b588a8f6d) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Polygon
+
+| Contract          | Address                                                                                                                  | Deployment                                                                     |
+| :---------------- | :----------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0xcf2d812d5aad4e6fec3b05850ff056b21159d496](https://polygonscan.com/address/0xcf2d812d5aad4e6fec3b05850ff056b21159d496) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x011277c87158e52cfbd8a1dd4a29118d602dda3a](https://polygonscan.com/address/0x011277c87158e52cfbd8a1dd4a29118d602dda3a) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Scroll
+
+| Contract          | Address                                                                                                                 | Deployment                                                                     |
+| :---------------- | :---------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x66826f53bffeaab71adc7fe1a77e86f8268848d8](https://scrollscan.com/address/0x66826f53bffeaab71adc7fe1a77e86f8268848d8) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x57fd892b3dc20eadb83cd8fb0240a87960046daa](https://scrollscan.com/address/0x57fd892b3dc20eadb83cd8fb0240a87960046daa) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Superseed
+
+| Contract          | Address                                                                                                                         | Deployment                                                                     |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x4f5f9b3fb57bba43aaf90e3f71d8f8f384e88e20](https://explorer.superseed.xyz/address/0x4f5f9b3fb57bba43aaf90e3f71d8f8f384e88e20) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xac2c36347869d8d779f7872c6202de3efd6ef2bb](https://explorer.superseed.xyz/address/0xac2c36347869d8d779f7872c6202de3efd6ef2bb) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Taiko Mainnet
+
+| Contract          | Address                                                                                                               | Deployment                                                                     |
+| :---------------- | :-------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x3d303e4c61285f87da9f61aaadc8c89b7d55dfa2](https://taikoscan.io/address/0x3d303e4c61285f87da9f61aaadc8c89b7d55dfa2) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xe790b6178612eeba6faeec16a2e1354c872f8bde](https://taikoscan.io/address/0xe790b6178612eeba6faeec16a2e1354c872f8bde) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Tangle
+
+| Contract          | Address                                                                                                                        | Deployment                                                                     |
+| :---------------- | :----------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0xCff4a803b0Bf55dD1BE38Fb96088478F3D2eeCF2](https://explorer.tangle.tools/address/0xCff4a803b0Bf55dD1BE38Fb96088478F3D2eeCF2) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x2De92156000269fa2fde7544F10f01E8cBC80fFa](http://explorer.tangle.tools/address/0x2De92156000269fa2fde7544F10f01E8cBC80fFa)  | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### zkSync Era
+
+| Contract          | Address                                                                                                                     | Deployment                                                                     |
+| :---------------- | :-------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x015899a075B7C181e357Cd0ed000683DBB4F1FcE](https://era.zksync.network/address/0x015899a075B7C181e357Cd0ed000683DBB4F1FcE) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x01C40608f2822816cF25a0a911c1df330487ba62](https://era.zksync.network/address/0x01C40608f2822816cF25a0a911c1df330487ba62) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
 
 ## Testnets
 
-Coming soon.
+### Sepolia
+
+| Contract          | Address                                                                                                                       | Deployment                                                                     |
+| :---------------- | :---------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x5ae8c13f6ae094887322012425b34b0919097d8a](https://sepolia.etherscan.io/address/0x5ae8c13f6ae094887322012425b34b0919097d8a) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xbc4da2fbdfe5c5eaa11bd0e282201e2abf40b1ee](https://sepolia.etherscan.io/address/0xbc4da2fbdfe5c5eaa11bd0e282201e2abf40b1ee) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Arbitrum Sepolia
+
+| Contract          | Address                                                                                                                      | Deployment                                                                     |
+| :---------------- | :--------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x781b3b2527f2a0a1e6b429161f2717a8a28b9f46](https://sepolia.arbiscan.io/address/0x781b3b2527f2a0a1e6b429161f2717a8a28b9f46) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x9a08e6ae67c28002ee2c7cff9badecd33ae2151c](https://sepolia.arbiscan.io/address/0x9a08e6ae67c28002ee2c7cff9badecd33ae2151c) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Base Sepolia
+
+| Contract          | Address                                                                                                                       | Deployment                                                                     |
+| :---------------- | :---------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0xd5f78708d83ac2bc8734a8cdf2d112c1bb3b62a2](https://sepolia.basescan.org/address/0xd5f78708d83ac2bc8734a8cdf2d112c1bb3b62a2) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x168ad0b246f604bc70bef87ecde585c3f1d49617](https://sepolia.basescan.org/address/0x168ad0b246f604bc70bef87ecde585c3f1d49617) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Berachain Bartio
+
+| Contract          | Address                                                                                                                      | Deployment                                                                     |
+| :---------------- | :--------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0xee4ee0b5c260e5cf559266d4a18a6f05ecd52d61](https://bartio.beratrail.io/address/0xee4ee0b5c260e5cf559266d4a18a6f05ecd52d61) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x6f41ffb18d451a4744ee713d0b5a68579877be5f](https://bartio.beratrail.io/address/0x6f41ffb18d451a4744ee713d0b5a68579877be5f) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Blast Sepolia
+
+| Contract          | Address                                                                                                                       | Deployment                                                                     |
+| :---------------- | :---------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0xa8c864c53e72301c2ab484d013627a5a7084174b](https://sepolia.blastscan.io/address/0xa8c864c53e72301c2ab484d013627a5a7084174b) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x567a95aa72a23b924f79dfa437d28c38740e144c](https://sepolia.blastscan.io/address/0x567a95aa72a23b924f79dfa437d28c38740e144c) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Linea Sepolia
+
+| Contract          | Address                                                                                                                          | Deployment                                                                     |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0xb0255ed1ee5c01dfe865c1b21bbf56a80f9ae739](https://sepolia.lineascan.build/address/0xb0255ed1ee5c01dfe865c1b21bbf56a80f9ae739) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xcd8871a22640c57ba36984fb57e9c794f5df7f40](https://sepolia.lineascan.build/address/0xcd8871a22640c57ba36984fb57e9c794f5df7f40) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Mode Sepolia
+
+| Contract          | Address                                                                                                                                | Deployment                                                                     |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0xf5ac60870e1ccc4bfce23cfbb7a796a0d8dbaf47](https://sepolia.explorer.mode.network/address/0xf5ac60870e1ccc4bfce23cfbb7a796a0d8dbaf47) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x1cae76b71913598d7664d16641ccb6037d8ed61a](https://sepolia.explorer.mode.network/address/0x1cae76b71913598d7664d16641ccb6037d8ed61a) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Morph Holesky
+
+| Contract          | Address                                                                                                                              | Deployment                                                                     |
+| :---------------- | :----------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x9efc8663cab0e2d97ad17c9fbfc8392445517e94](https://explorer-holesky.morphl2.io/address/0x9efc8663cab0e2d97ad17c9fbfc8392445517e94) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x3d664b2da905ddd0db931982fd9a759ea950d6e1](https://explorer-holesky.morphl2.io/address/0x3d664b2da905ddd0db931982fd9a759ea950d6e1) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Optimism Sepolia
+
+| Contract          | Address                                                                                                                                  | Deployment                                                                     |
+| :---------------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x417db0f2bd020fc4d6bccea6b2bb6be0c541862e](https://sepolia-optimistic.etherscan.io/address/0x417db0f2bd020fc4d6bccea6b2bb6be0c541862e) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x28401987a23ed9b8926b07f3b6855222a70c2128](https://sepolia-optimistic.etherscan.io/address/0x28401987a23ed9b8926b07f3b6855222a70c2128) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Superseed Sepolia
+
+| Contract          | Address                                                                                                                                 | Deployment                                                                     |
+| :---------------- | :-------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x905756b52efeaf75f6b1bb1bb0fc35eea15ae260](https://sepolia-explorer.superseed.xyz/address/0x905756b52efeaf75f6b1bb1bb0fc35eea15ae260) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xc43fb9fe4477d8e8bf68b9fd3a0163a4cffcbb31](https://sepolia-explorer.superseed.xyz/address/0xc43fb9fe4477d8e8bf68b9fd3a0163a4cffcbb31) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### Taiko Hekla
+
+| Contract          | Address                                                                                                                     | Deployment                                                                     |
+| :---------------- | :-------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x29b7bafce0a04638dc91ca0b87a562cab8c3dbde](https://hekla.taikoscan.io/address/0x29b7bafce0a04638dc91ca0b87a562cab8c3dbde) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0xd45f45dd34045a368854f7987a84d9485b4b45e9](https://hekla.taikoscan.io/address/0xd45f45dd34045a368854f7987a84d9485b4b45e9) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+
+### zkSync Sepolia
+
+| Contract          | Address                                                                                                                             | Deployment                                                                     |
+| :---------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| SablierFlow       | [0x8e70296f8972ebe94d885b1caf94da4836976140](https://sepolia-era.zksync.network/address/0x8e70296f8972ebe94d885b1caf94da4836976140) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |
+| FlowNFTDescriptor | [0x900277DBB45a04eB79028b3A44c650Ac81Ca86c4](https://sepolia-era.zksync.network/address/0x900277DBB45a04eB79028b3A44c650Ac81Ca86c4) | [v1.0.0](https://github.com/sablier-labs/v2-deployments/tree/main/flow/v1.0.0) |


### PR DESCRIPTION
This PR introduces the `flow` deployed addresses across all chains that `lockup` protocol is deployed.