### PR TITLE
fix: support how to 404

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -106,6 +106,10 @@ const config: Config = {
             to: "/apps/features/overview",
           },
           {
+            from: "/apps/support/how-to",
+            to: "/support/how-to",
+          },
+          {
             from: "/apps/url-schemes",
             to: "/apps/guides/url-schemes",
           },


### PR DESCRIPTION
Fix page has links to [broken page.](https://app.ahrefs.com/site-audit/7006528/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2CcontentType%2Cdepth%2ClinksInternal4xx%2ClinksCountInternal4xx%2ClinksExternal4xx%2ClinksCountExternal4xx&filterId=ef910605970b081acfca3ff161170299&issueId=c64daf06-d0f4-11e7-8ed1-001e67ed4656&sorting=-pageRating)

<img width="1173" alt="x" src="https://github.com/user-attachments/assets/c6a30ad8-f5fc-4bf7-ad7d-e1cc34f028cf" />
