### PR TITLE
refactor: singular protocol

### DIFF
--- a/docs/apps/guides/02-url-schemes.mdx
+++ b/docs/apps/guides/02-url-schemes.mdx
@@ -15,7 +15,7 @@ cover a number of resource locators used by the apps, as well as dive into how y
 
 ### Elements
 
-Every stream created through the Sablier Protocols is identified through three parameters:
+Every stream created through the Sablier Protocol is identified through three parameters:
 
 - a **chainId** (e.g., `1` for Ethereum, `10` for [OP Mainnet](https://chainlist.org/) )
 - an **alias** (e.g., `LK`) OR a **contract** (e.g. `0x12..AB`)

--- a/docs/concepts/01-what-is-sablier.mdx
+++ b/docs/concepts/01-what-is-sablier.mdx
@@ -13,13 +13,13 @@ import ReleaseHistoryLockup from "@site/docs/snippets/ReleaseHistoryLockup.mdx";
 Sablier is the powerhouse of token distribution protocols. We build decentralized applications to distribute your tokens
 from one account to another, in realtime.
 
-- **The Sablier Protocols**: A collection of persistent, non-upgradeable smart contracts to facilitate streaming of
-  ERC-20 tokens on Ethereum and other EVM blockchains. The Sablier Protocols consist of Lockup, Merkle Airdrops and
+- **The Sablier Protocol**: A collection of persistent, non-upgradeable smart contracts to facilitate streaming of
+  ERC-20 tokens on Ethereum and other EVM blockchains. The Sablier Protocol consists of Lockup, Merkle Airdrops, and
   Flow.
-- **The Sablier Interface**: A web interface that allows for easy interaction with the Sablier Protocols. The interface
-  is only one of many ways to interact with the Sablier Protocols.
-- **Sablier Labs**: The company that develops the Sablier Protocols, the Sablier Interface, and the documentation
-  website you are reading right now.
+- **The Sablier Interface**: A web interface that allows for easy interaction with the Sablier Protocol. The interface
+  is only one of many ways to interact with the Sablier Protocol.
+- **Sablier Labs**: The company that develops the Sablier Protocol, the Sablier Interface, and the documentation website
+  you are reading right now.
 
 :::info
 
@@ -27,47 +27,38 @@ Fun fact: "sablier" means "hourglass" in French.
 
 :::
 
-## Sablier Protocols
+## Sablier Protocol
 
-Sablier protocols are a collection of token distribution protocols developed with [Ethereum](https://ethereum.org/)
-smart contracts, designed to facilitate by-the-second payments for cryptocurrencies, specifically
-[ERC-20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) tokens. The protocols employ a set of
+A software protocol built with [Ethereum](https://ethereum.org/) smart contracts, designed to facilitate distribution of
+[ERC-20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) tokens. The protocol employs a set of
 persistent and non-upgradable smart contracts that prioritize security, censorship resistance, self-custody, and
 functionality without the need for trusted intermediaries who may selectively restrict access.
 
-Currently, it consists of three protocols: **Lockup** to facilitates vesting and airstreams, **Merkle Airdrops** to
-enable on-chain airdrops and **Flow** for payroll, grants etc. All of these are licensed under BUSL-1.1, and are
-open-source and can be accessed on Sablier's [GitHub page](https://github.com/sablier-labs). Detailed technical
-reference for each protocol can be found in the [Technical References](/reference/overview) section of this website.
+Currently, Sablier consists of three separate systems:
 
-As long as Ethereum and the other EVM chains continue to exist, every version of Sablier protocols that gets deployed
+- **Lockup**: facilitates vesting and vested airdrops
+- **Merkle Airdrops**: enables on-chain airdrops
+- **Flow**: for payroll, grants etc.
+
+All of these are licensed under BUSL-1.1 and GPL v3, and the source code can be accessed on Sablier's
+[GitHub account](https://github.com/sablier-labs). Detailed technical reference for each protocol can be found in the
+[Technical References](/reference/overview) section of this website.
+
+As long as Ethereum and the other EVM chains continue to exist, every version of the Sablier Protocol that gets deployed
 will operate continuously and without interruption, with a guarantee of 100% uptime.
 
 :::info
 
-Sablier is the first token streaming protocol ever built, tracing its roots back to 2019.
+Sablier is the first project to enable token streaming in the Ethereum ecosystem, tracing its roots
+[back to 2019](https://x.com/Sablier/status/1205533344886411264).
 
 :::
 
 ## How does Sablier differ from traditional payment systems?
 
-To understand the unique characteristics of Sablier, it is helpful to examine two aspects: the concept of streaming as
-an alternative to conventional payment methods, and the permissionless nature of the protocol compared to traditional
-systems.
-
-### Streaming vs conventional payments
-
-Traditional payment systems generally involve lump-sum transfers, which rely on trust between parties, have slow
-processing times, and are prone to errors. In the context of bank transfers, payments are also subject to substantial
-fees and can face delays due to intermediaries.
-
-By contrast, Sablier introduces the concept of token streaming, enabling users to make continuous, real-time payments on
-a per-second basis. This innovative approach enables seamless, frictionless transactions and promotes increased
-financial flexibility for users, businesses, and other entities. Sablier makes the passage of time itself the
-trust-binding mechanism, unlocking business opportunities that were previously unavailable.
-
-A good mental model to contrast streaming with conventional payment models is to view the former as "real-time finance"
-or "continuous finance", and the latter as of "discrete finance".
+To understand the unique characteristics of Sablier, it is helpful to examine two aspects: the permissionless nature of
+the protocol compared to traditional payment systems, the concept of streaming as an alternative to conventional payment
+methods.
 
 ### Permissionless systems
 
@@ -85,9 +76,23 @@ As an immutable system, the Sablier Protocol is non-upgradeable, meaning that no
 transactions, or alter the users' streams in any way. This ensures the system remains transparent, secure, and resistant
 to manipulation or abuse.
 
+### Streaming vs conventional payments
+
+Traditional payment systems generally involve lump-sum transfers, which rely on trust between parties, have slow
+processing times, and are prone to errors. In the context of bank transfers, payments are also subject to substantial
+fees and can face delays due to intermediaries.
+
+By contrast, Sablier introduces the concept of token streaming, enabling users to make continuous, real-time payments on
+a per-second basis. This innovative approach enables seamless, frictionless transactions and promotes increased
+financial flexibility for users, businesses, and other entities. Sablier makes the passage of time itself the
+trust-binding mechanism, unlocking business opportunities that were previously unavailable.
+
+A good mental model to contrast streaming with conventional payment models is to view the former as "real-time finance"
+or "continuous finance", and the latter as of "discrete finance".
+
 ## Where can I find more information?
 
-For more details on the Sablier Protocols, their features, and potential use cases, explore this documentation site and
+For more details on the Sablier Protocol, its features, and potential use cases, explore this documentation site and
 visit the official [Sablier website](https://sablier.com) as well.
 
 :::tip

--- a/docs/concepts/01-what-is-sablier.mdx
+++ b/docs/concepts/01-what-is-sablier.mdx
@@ -10,8 +10,7 @@ import ReleaseHistoryFlow from "@site/docs/snippets/ReleaseHistoryFlow.mdx";
 import ReleaseHistoryLegacy from "@site/docs/snippets/ReleaseHistoryLegacy.mdx";
 import ReleaseHistoryLockup from "@site/docs/snippets/ReleaseHistoryLockup.mdx";
 
-Sablier is the powerhouse of token distribution protocols. We build decentralized applications to distribute your tokens
-from one account to another, in realtime.
+Sablier is a powerful onchain token distribution protocol. Here are some key definitions:
 
 - **The Sablier Protocol**: A collection of persistent, non-upgradeable smart contracts to facilitate streaming of
   ERC-20 tokens on Ethereum and other EVM blockchains. The Sablier Protocol consists of Lockup, Merkle Airdrops, and
@@ -40,9 +39,9 @@ Currently, Sablier consists of three separate systems:
 - **Merkle Airdrops**: enables on-chain airdrops
 - **Flow**: for payroll, grants etc.
 
-All of these are licensed under BUSL-1.1 and GPL v3, and the source code can be accessed on Sablier's
-[GitHub account](https://github.com/sablier-labs). Detailed technical reference for each protocol can be found in the
-[Technical References](/reference/overview) section of this website.
+While most of these are licensed under BUSL-1.1, there are some components licensed under GPL v3. The source code can be
+accessed on Sablier's [GitHub account](https://github.com/sablier-labs), and a detailed technical reference can be found
+in the [Technical References](/reference/overview) section of this website.
 
 As long as Ethereum and the other EVM chains continue to exist, every version of the Sablier Protocol that gets deployed
 will operate continuously and without interruption, with a guarantee of 100% uptime.

--- a/docs/concepts/07-nft.mdx
+++ b/docs/concepts/07-nft.mdx
@@ -78,9 +78,8 @@ some of the marketplaces that support Sablier streams:
 The SVG artwork is generated using certain real-time values, such as the current time on the blockchain. However, NFT
 marketplaces cache the NFT metadata, and this may cause the SVGs might not always be up to date.
 
-Sablier Protocols trigger [ERC-4906](https://eips.ethereum.org/EIPS/eip-4906) events whenever there's an update in a
-stream (for instance, when a withdrawal is made). However, it's worth noting that some streams might remain unchanged
-for an extended period.
+The Sablier Protocol triggers [ERC-4906](https://eips.ethereum.org/EIPS/eip-4906) events whenever there's an update in a
+stream (for instance, when a withdrawal is made). However, some streams might remain unchanged for an extended period.
 
 To ensure you're viewing the most recent version of the NFT SVG, it's recommended to check the stream directly via the
 [Sablier Interface](https://app.sablier.com).

--- a/docs/concepts/10-governance.md
+++ b/docs/concepts/10-governance.md
@@ -4,12 +4,12 @@ sidebar_position: 10
 title: "Governance"
 ---
 
-The Protocol Admin is an account with exclusive access to specific functions of the protocols. More concretely, the
-Admin is a collection of multisig wallets and EOAs currently in control of Sablier Labs.
+The Protocol Admin is an account with exclusive access to specific functions. More concretely, the Admin is a collection
+of multisig wallets and EOAs currently in control of Sablier Labs.
 
 ## Admins
 
-Here's a table with the protocols admin of the Sablier Protocol. Most of them are Safe multi-signature wallets.
+Here's a table with the admins of the Sablier Protocol. Most of them are Safe multi-signature wallets.
 
 | Chain           | Address                                                                                                                          |
 | :-------------- | :------------------------------------------------------------------------------------------------------------------------------- |
@@ -70,8 +70,8 @@ Admin has the following permissions on each chain where `Flow` is deployed:
 
 Despite having an admin, the Sablier Protocol remains trustless. Here's why:
 
-1. The protocols are permissionless, i.e. it can be freely accessed by anyone with an Internet connection.
-2. The protocols are persistent, i.e. the admin cannot pause it.
+1. The protocol is permissionless, i.e. it can be freely accessed by anyone with an Internet connection.
+2. The protocol is persistent, i.e. the admin cannot pause it.
 3. The streaming logic is non-upgradeable, i.e. the admin cannot tamper with the streams created by users.
 4. There are no escape hatches that allow the admin to claim user funds.
 5. There is a hard-coded upper limit of 10% to the fees that the admin can charge.

--- a/docs/concepts/10-governance.md
+++ b/docs/concepts/10-governance.md
@@ -9,8 +9,7 @@ Admin is a collection of multisig wallets and EOAs currently in control of Sabli
 
 ## Admins
 
-Here are the addresses that are the protocols admin for the Sablier Protocols. Most of them are Safe multi-signature
-wallets.
+Here's a table with the protocols admin of the Sablier Protocol. Most of them are Safe multi-signature wallets.
 
 | Chain           | Address                                                                                                                          |
 | :-------------- | :------------------------------------------------------------------------------------------------------------------------------- |
@@ -69,7 +68,7 @@ Admin has the following permissions on each chain where `Flow` is deployed:
 
 ## Trustlessness
 
-Despite having an admin, the Sablier Protocols remain trustless. Here are the reasons why:
+Despite having an admin, the Sablier Protocol remains trustless. Here's why:
 
 1. The protocols are permissionless, i.e. it can be freely accessed by anyone with an Internet connection.
 2. The protocols are persistent, i.e. the admin cannot pause it.

--- a/docs/concepts/12-security.md
+++ b/docs/concepts/12-security.md
@@ -4,7 +4,7 @@ sidebar_position: 12
 title: "Security"
 ---
 
-Ensuring the security of the Sablier Protocols is our utmost priority. We have dedicated significant efforts towards the
+Ensuring the security of the Sablier Protocol is our utmost priority. We have dedicated significant efforts towards the
 design and testing of the protocol to guarantee its safety and reliability.
 
 The Sablier contracts have undergone rigorous audits by leading security experts from [Cantina](https://cantina.xyz/),
@@ -26,7 +26,7 @@ All the audits of Lockup contracts can be found [here](https://github.com/sablie
 
 ## Bug Bounty
 
-The Sablier Protocols are subject to a bug bounty program per the terms outlined in `Security.md` of each protocol.
+The Sablier Protocol is subject to a bug bounty program per the terms outlined in `Security.md` of each protocol.
 
 - [Lockup Bug Bounty](https://github.com/sablier-labs/lockup/blob/main/SECURITY.md)
 - [Merkle Airdrops Bug Bounty](https://github.com/sablier-labs/airdrops/blob/main/SECURITY.md).

--- a/docs/concepts/13-glossary.md
+++ b/docs/concepts/13-glossary.md
@@ -6,7 +6,7 @@ title: "Glossary"
 
 ## Broker
 
-A third-party entity that interacts with the Sablier Protocols on behalf of its users, who may charge service fees for
+A third-party entity that interacts with the Sablier Protocol on behalf of its users, who may charge service fees for
 facilitating these interactions.
 
 ## Broker Fee
@@ -78,7 +78,7 @@ The amount of tokens that sender owes to the stream.
 
 ## Foundry
 
-[Foundry][foundry] is the application development toolkit that has been used to develop the Sablier Protocols.
+[Foundry][foundry] is the application development toolkit that has been used to develop the Sablier Protocol.
 
 ## Gas Fee
 
@@ -201,7 +201,7 @@ Aa data structure used to store hashes of the recipients airdrop allocations in 
 
 ## PRBMath
 
-[PRBMath][prb-math] is fixed-point arithmetic library used by Sablier protocols.
+[PRBMath][prb-math] is fixed-point arithmetic library used by the Sablier Protocol for precise calculations.
 
 ## Protocol Admin
 
@@ -209,7 +209,7 @@ An entity with exclusive access to specific functions of the protocol.
 
 ## Real-time finance
 
-A term coined by us in 2019 to emphasize the wide-ranging use cases for the Sablier Protocols.
+A term coined by us in 2019 to emphasize the wide-ranging use cases for the Sablier Protocol.
 
 Since the withdrawable amounts in streams are updated every second, they embody the concept of real-time financial
 transactions.
@@ -227,8 +227,7 @@ By-the-second payments.
 
 ## Token
 
-Digital tokens can exist in various forms, but the Sablier Protocols exclusively supports the streaming of ERC-20
-tokens.
+Digital tokens can exist in various forms, but the Sablier Protocol exclusively supports the streaming of ERC-20 tokens.
 
 ## Vesting
 

--- a/docs/concepts/13-glossary.md
+++ b/docs/concepts/13-glossary.md
@@ -218,8 +218,8 @@ transactions.
 
 A new financial primitive that permits by-the-second payments.
 
-Currently, Sablier offers two streaming protocols called Lockup and Flow. In Lockup, the creator has to lock up a
-specified amount of tokens whereas in Flow protocol, creator is not required to lock up any amount of tokens.
+Currently, Sablier offers two distribution protocols called Lockup and Flow. In Lockup, the creator has to lock up a
+specified amount of tokens, whereas in Flow, creator is not required to lock up any amount of tokens.
 
 ## Streaming
 

--- a/docs/guides/04-custom-deployments.mdx
+++ b/docs/guides/04-custom-deployments.mdx
@@ -9,7 +9,7 @@ import { links } from "@site/src/constants";
 
 :::info[Reach Out]
 
-We are unable to deploy the Sablier Protocols on every EVM chain. However, we would be happy to consider your project if
+We are unable to deploy the Sablier Protocol on every EVM chain. However, we would be happy to consider your project if
 you fill out this <Link href={links.forms.chains}>form</Link> and meet the requirements below.
 
 :::

--- a/docs/guides/04-custom-deployments.mdx
+++ b/docs/guides/04-custom-deployments.mdx
@@ -25,7 +25,7 @@ you fill out this <Link href={links.forms.chains}>form</Link> and meet the requi
 :::warning[LEGAL]
 
 The following guidelines apply to you ONLY IF you have you been granted a
-[BUSL license](https://app.ens.domains/license-grants.sablier.eth?tab=records) to deploy the protocols.
+[BUSL license](https://app.ens.domains/license-grants.sablier.eth?tab=records) to deploy the protocol.
 
 :::
 

--- a/docs/guides/06-frontend.md
+++ b/docs/guides/06-frontend.md
@@ -5,13 +5,12 @@ id: "frontend"
 title: "Frontend Integrations"
 ---
 
-Throughout this series, we've been focusing on creating an onchain integration with Sablier protocols. But maybe you're
-interested in developing a front-end app. No worries! In this guide, we'll provide some pointers on how to go about it.
+Throughout this series, we've been focusing on creating an onchain integration with Sablier. But maybe you're interested
+in developing a front-end app. No worries! In this guide, we'll provide some pointers on how to go about it.
 
 ## Toolset
 
-There's no one-size-fits-all toolset for building front-end integrations of Sablier but for this guide we'll recommend
-the following:
+There's no one-size-fits-all toolset for building front-end integrations of Sablier, but we recommend using:
 
 - [Next.js](https://nextjs.org/)
 - [React](https://reactjs.org/)

--- a/docs/reference/01-overview.md
+++ b/docs/reference/01-overview.md
@@ -4,11 +4,10 @@ sidebar_position: 1
 title: "Overview"
 ---
 
-All Sablier protocols are a binary smart contract system comprised of many abstract contracts, libraries, and types. The
-design of the Sablier smart contracts draws inspiration from the architectural principles of
-[Uniswap](https://docs.uniswap.org/).
+The Sablier Protocol is a smart contract system comprised of many abstract contracts, libraries, and types. The design
+of the smart contracts draws some inspiration from the architectural principles of [Uniswap](https://docs.uniswap.org).
 
-This section provides a detailed overview of the Sablier smart contracts, their designs, control flows and contract
+This section provides a detailed overview of the Sablier smart contracts, their designs, control flows, and contract
 references.
 
 ## Lockup

--- a/docs/reference/06-errors.md
+++ b/docs/reference/06-errors.md
@@ -6,7 +6,7 @@ title: "Errors"
 
 ## Background
 
-Sablier protocols handle errors with the convenient and gas-efficient
+The Sablier Protocol handles errors with the convenient and gas-efficient
 [custom error syntax](https://blog.soliditylang.org/2021/04/21/custom-errors) introduced in Solidity v0.8.4.
 
 The error data encoding is identical to the ABI encoding used for functions, e.g.:
@@ -24,7 +24,7 @@ bytes4(keccak256(bytes("SablierLockupBase_WithdrawAmountZero(uint256)")))
 
 ## Naming Pattern
 
-With the exception of a few generics, all errors in Sablier protocols adhere to the naming pattern
+With the exception of a few generics, all errors in Sablier Protocol adhere to the naming pattern
 `<ContractName>_<ErrorName>`.
 
 Incorporating the contract name as a prefix offers context, making it easier for end users to pinpoint the contract

--- a/docs/support/01-faq.mdx
+++ b/docs/support/01-faq.mdx
@@ -4,17 +4,13 @@ sidebar_position: 1
 title: "FAQ"
 ---
 
-### Where can I access the Sablier protocols?
+### Where can I access the Sablier Protocol?
 
 You can access Sablier through the following web interfaces:
 
 - [app.sablier.com](https://app.sablier.com)
-- [app.safe.global](https://app.safe.global) (if you are using a Safe multisig wallet)
-
-### What is real-time finance?
-
-A term coined by us to emphasize the wide-ranging use cases for the Sablier protocols. We like to think about work as an
-attempt to rethink the way trust is established in financial contracts.
+- [app.safe.global](https://app.safe.global/share/safe-app?appUrl=https%3A%2F%2Fapp.sablier.com%2F&chain=arb1) (if you
+  are using a Safe multisig wallet)
 
 ### What is token streaming?
 
@@ -31,6 +27,15 @@ Imagine Alice wants to stream 3000 DAI to Bob during the whole month of January.
 4. If at any point during January Alice wishes to get back her tokens, she can cancel the stream and recover what has
    not been streamed yet.
 
+### How does Lockup calculate the payment rate?
+
+Dividing the deposit amount by the difference between the stop time and the start time gives us a payment rate per
+second. Lockup uses this rate to transfer a small portion of tokens from the sender to the recipient once every second.
+
+For instance, if the payment rate was 0.01 DAI per second, the recipient would receive:
+
+$0.01 * 60 = 0.6$ DAI / minute, $0.01 * 60 * 60 = 36$ DAI / hour, $0.01 * 60 * 60 * 24 = 864$ DAI / day
+
 ### How does streaming work on Sablier Flow?
 
 Imagine Alice wants to stream 3000 DAI on a monthly basis to Bob.
@@ -44,22 +49,13 @@ Imagine Alice wants to stream 3000 DAI on a monthly basis to Bob.
 
 ### How can I create a stream?
 
-You will need an EVM wallet ([Metamask](https://metamask.io), [Rainbow](https://rainbow.me), etc.), some ETH (or the
-network's token to pay gas fees) and an ERC-20 token like DAI. Then, choose your favorite interface for accessing the
-Sablier protocols (such as [app.sablier.com](https://app.sablier.com)) and fill in the recipient's address, the deposit
-amount and the total duration.
+You will need an EVM wallet (e.g. [Metamask](https://metamask.io), [Rainbow](https://rainbow.me), etc.), some ETH (or
+the network's token to pay gas fees) and an ERC-20 token like DAI. Then, choose your favorite interface for accessing
+the Sablier Protocol (such as [app.sablier.com](https://app.sablier.com)) and fill in the recipient's address, the
+deposit amount and the total duration.
 
 Alternatively, you can see [here](/guides/lockup/etherscan) how to manually create a stream using
 [Etherscan](https://etherscan.io).
-
-### How does Lockup streaming work?
-
-Dividing the deposit amount by the difference between the stop time and the start time gives us a payment rate per
-second. Lockup uses this rate to transfer a small portion of tokens from the sender to the recipient once every second.
-
-For instance, if the payment rate was 0.01 DAI per second, the recipient would receive:
-
-$0.01 * 60 = 0.6$ DAI / minute, $0.01 * 60 * 60 = 36$ DAI / hour, $0.01 * 60 * 60 * 24 = 864$ DAI / day
 
 ### Where are the tokens held?
 
@@ -86,8 +82,8 @@ transfers all the remaining funds (if any) to the recipient.
 
 ### Can I modify the streaming rate?
 
-On Lockup, once a stream is created, it is set in stone on the Ethereum blockchain. Whereas on Flow, a stream rate per
-second can be modified anytime by the creator.
+On Lockup, once a stream is created, it is set in stone on the Ethereum blockchain. Whereas on Flow, the streaming rate
+per second can be adjusted anytime by the sender.
 
 ### How are vested airdrops different from a batch of normal streams?
 
@@ -104,8 +100,13 @@ one after the other (as opposed to all at once).
 
 | Feature                        | Groups                           | Airdrops              |
 | ------------------------------ | -------------------------------- | --------------------- |
-| Maximum number of streams      | ~60 (depends on block gas limit) | Millions              |
+| Maximum number of streams      | ~280 (different limit per chain) | Millions              |
 | Gas to create streams          | Sender paying                    | Each recipient paying |
 | Gas to deploy Airdrop contract | N/A                              | Sender paying         |
 | Streams show up onchain        | Immediately                      | Lazily                |
 | Good for                       | Investors, Employees             | Large communities     |
+
+### What is real-time finance?
+
+A term coined by us to emphasize the wide-ranging use cases for the Sablier Protocol. We like to think about work as an
+attempt to rethink the way trust is established in financial contracts.


### PR DESCRIPTION
cc @smol-ninja since I think you were the one who made this change

I think we should restrict the word 'protocol' to the underlying blockchain architecture used

i.e. every token distribution product shipped by Sablier on the EVM will be part of the same unified _Sablier Protocol_

One and only!