### PR TITLE
chore: added supported networks table in documentation

### DIFF
--- a/docs/concepts/07-chains.mdx
+++ b/docs/concepts/07-chains.mdx
@@ -1,0 +1,58 @@
+---
+id: chains
+title: Supported Chains
+sidebar_position: 7
+---
+
+import Link from "@docusaurus/Link";
+import { links } from "@site/src/constants";
+
+{/* prettier-ignore */}
+Sablier Protocol is live on 25 mainnets and 11 testnets. Do you want to get Sablier deployed on your chain? If you meet the [requirements](/guides/custom-deployments#requirements)
+for custom deployment, fill out <Link href={links.forms.chains}>this form</Link> and our team will get back to you.
+
+## Mainnets
+
+| Chain           | Chain ID | Gas Token | Decimals | Block Explorer                               |
+| --------------- | -------- | --------- | -------- | -------------------------------------------- |
+| Ethereum        | 1        | ETH       | 18       | [Explorer](https://etherscan.io)             |
+| Abstract        | 2741     | ETH       | 18       | [Explorer](https://abscan.org/)              |
+| Arbitrum        | 42161    | ETH       | 18       | [Explorer](https://arbiscan.io)              |
+| Avalanche       | 43114    | AVAX      | 18       | [Explorer](https://snowtrace.io)             |
+| Base            | 8453     | ETH       | 18       | [Explorer](https://basescan.org)             |
+| Berachain       | 80094    | BERA      | 18       | [Explorer](https://berascan.com/)            |
+| Blast           | 81457    | ETH       | 18       | [Explorer](https://blastscan.io)             |
+| BNB Smart Chain | 56       | BNB       | 18       | [Explorer](https://bscscan.com)              |
+| Chiliz          | 88888    | CHZ       | 18       | [Explorer](https://chiliscan.com/)           |
+| Core DAO        | 1116     | CORE      | 18       | [Explorer](https://scan.coredao.org/)        |
+| Form            | 478      | ETH       | 18       | [Explorer](https://explorer.form.network/)   |
+| Gnosis          | 100      | xDAI      | 18       | [Explorer](https://gnosisscan.io)            |
+| IoTeX           | 4689     | IOTX      | 18       | [Explorer](https://iotexscan.io)             |
+| Lightlink       | 1890     | ETH       | 18       | [Explorer](https://phoenix.lightlink.io)     |
+| Linea           | 59144    | ETH       | 18       | [Explorer](https://lineascan.build)          |
+| Mode            | 34443    | ETH       | 18       | [Explorer](https://explorer.mode.network)    |
+| Morph           | 2818     | ETH       | 18       | [Explorer](https://explorer.morphl2.io)      |
+| Optimism        | 10       | ETH       | 18       | [Explorer](https://optimistic.etherscan.io/) |
+| Polygon         | 137      | POL       | 18       | [Explorer](https://polygonscan.com)          |
+| Scroll          | 534352   | ETH       | 18       | [Explorer](https://scrollscan.com)           |
+| Superseed       | 5330     | ETH       | 18       | [Explorer](https://explorer.superseed.xyz/)  |
+| Taiko           | 167000   | ETH       | 18       | [Explorer](https://taikoscan.io/)            |
+| Tangle          | 5845     | TNT       | 18       | [Explorer](https://explorer.tangle.tools/)   |
+| XDC             | 50       | XDC       | 18       | [Explorer](https://xdcscan.com/)             |
+| zkSync Era      | 324      | ETH       | 18       | [Explorer](https://era.zksync.network/)      |
+
+## Testnets
+
+| Chain             | Chain ID  | Gas Token | Decimals | Block Explorer                                      |
+| ----------------- | --------- | --------- | -------- | --------------------------------------------------- |
+| Ethereum Sepolia  | 11155111  | ETH       | 18       | [Explorer](https://sepolia.etherscan.io)            |
+| Arbitrum Sepolia  | 421614    | ETH       | 18       | [Explorer](https://sepolia.arbiscan.io)             |
+| Base Sepolia      | 84532     | ETH       | 18       | [Explorer](https://sepolia.basescan.org)            |
+| Blast Sepolia     | 168587773 | ETH       | 18       | [Explorer](https://sepolia.blastscan.io/)           |
+| Linea Sepolia     | 59141     | ETH       | 18       | [Explorer](https://sepolia.lineascan.build/)        |
+| Mode Sepolia      | 919       | ETH       | 18       | [Explorer](https://sepolia.explorer.mode.network/)  |
+| Monad Testnet     | 10143     | MON       | 18       | [Explorer](https://testnet.monadexplorer.com/)      |
+| Optimism Sepolia  | 11155420  | ETH       | 18       | [Explorer](https://sepolia-optimism.etherscan.io)   |
+| Superseed Sepolia | 53302     | ETH       | 18       | [Explorer](https://sepolia-explorer.superseed.xyz/) |
+| Taiko Hekla       | 167009    | ETH       | 18       | [Explorer](https://hekla.taikoexplorer.com/)        |
+| zkSync Sepolia    | 300       | ETH       | 18       | [Explorer](https://sepolia-era.zksync.network/)     |

--- a/docs/concepts/08-nft.mdx
+++ b/docs/concepts/08-nft.mdx
@@ -1,6 +1,6 @@
 ---
 id: "nft"
-sidebar_position: 7
+sidebar_position: 8
 title: "NFTs"
 ---
 

--- a/docs/concepts/09-cancelability.md
+++ b/docs/concepts/09-cancelability.md
@@ -1,6 +1,6 @@
 ---
 id: "cancelability"
-sidebar_position: 8
+sidebar_position: 9
 title: "Cancelability"
 ---
 

--- a/docs/concepts/10-transferability.md
+++ b/docs/concepts/10-transferability.md
@@ -1,6 +1,6 @@
 ---
 id: "transferability"
-sidebar_position: 9
+sidebar_position: 10
 title: "Transferability"
 ---
 

--- a/docs/concepts/11-governance.md
+++ b/docs/concepts/11-governance.md
@@ -1,6 +1,6 @@
 ---
 id: "governance"
-sidebar_position: 10
+sidebar_position: 11
 title: "Governance"
 ---
 

--- a/docs/concepts/12-fees.mdx
+++ b/docs/concepts/12-fees.mdx
@@ -1,6 +1,6 @@
 ---
 id: "fees"
-sidebar_position: 11
+sidebar_position: 12
 title: "Fees"
 ---
 

--- a/docs/concepts/13-security.md
+++ b/docs/concepts/13-security.md
@@ -1,6 +1,6 @@
 ---
 id: "security"
-sidebar_position: 12
+sidebar_position: 13
 title: "Security"
 ---
 

--- a/docs/concepts/14-glossary.md
+++ b/docs/concepts/14-glossary.md
@@ -1,6 +1,6 @@
 ---
 id: "glossary"
-sidebar_position: 13
+sidebar_position: 14
 title: "Glossary"
 ---
 

--- a/docs/guides/04-custom-deployments.mdx
+++ b/docs/guides/04-custom-deployments.mdx
@@ -10,8 +10,8 @@ import { links } from "@site/src/constants";
 :::info[Reach Out]
 
 {/* prettier-ignore */}
-Want to get Sablier deployed on your chain? If you meet the requirements listed below, feel out this <Link href={links.forms.chains}>form</Link>
-and our team will get back to you.
+Want to get Sablier deployed on your chain? If you meet the requirements listed below, fill out <Link href={links.forms.chains}>this
+form</Link> and our team will get back to you.
 
 :::
 

--- a/docs/guides/airdrops/02-deployments.md
+++ b/docs/guides/airdrops/02-deployments.md
@@ -225,9 +225,9 @@ discontinued. For previous deployments, please refer to the
 
 ### Taiko Hekla
 
-| Contract             | Address                                                                                                                       | Deployment                                                                      |
-| :------------------- | :---------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| SablierMerkleFactory | [0xB5F4FB527568f88F8898Ce5F366f4d72e2C742BE](https://sepolia.taikoscan.io/address/0xB5F4FB527568f88F8898Ce5F366f4d72e2C742BE) | [v1.3.0](https://github.com/sablier-labs/deployments/blob/main/airdrops/v1.3.0) |
+| Contract             | Address                                                                                                                          | Deployment                                                                      |
+| :------------------- | :------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| SablierMerkleFactory | [0xB5F4FB527568f88F8898Ce5F366f4d72e2C742BE](https://hekla.taikoexplorer.com/address/0xB5F4FB527568f88F8898Ce5F366f4d72e2C742BE) | [v1.3.0](https://github.com/sablier-labs/deployments/blob/main/airdrops/v1.3.0) |
 
 ### zkSync Sepolia
 

--- a/docs/guides/flow/02-deployments.mdx
+++ b/docs/guides/flow/02-deployments.mdx
@@ -277,10 +277,10 @@ Sablier repositories on Github.
 
 ### Taiko Hekla
 
-| Contract          | Address                                                                                                                       | Deployment                                                                  |
-| :---------------- | :---------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
-| SablierFlow       | [0xb528AF43fFEe6d4B702CF6235d2380e1828eD852](https://sepolia.taikoscan.io/address/0xb528AF43fFEe6d4B702CF6235d2380e1828eD852) | [v1.1.0](https://github.com/sablier-labs/deployments/blob/main/flow/v1.1.0) |
-| FlowNFTDescriptor | [0xB197D4142b9DBf34979588cf8BF1222Ea3907916](https://sepolia.taikoscan.io/address/0xB197D4142b9DBf34979588cf8BF1222Ea3907916) | [v1.1.0](https://github.com/sablier-labs/deployments/blob/main/flow/v1.1.0) |
+| Contract          | Address                                                                                                                          | Deployment                                                                  |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
+| SablierFlow       | [0xb528AF43fFEe6d4B702CF6235d2380e1828eD852](https://hekla.taikoexplorer.com/address/0xb528AF43fFEe6d4B702CF6235d2380e1828eD852) | [v1.1.0](https://github.com/sablier-labs/deployments/blob/main/flow/v1.1.0) |
+| FlowNFTDescriptor | [0xB197D4142b9DBf34979588cf8BF1222Ea3907916](https://hekla.taikoexplorer.com/address/0xB197D4142b9DBf34979588cf8BF1222Ea3907916) | [v1.1.0](https://github.com/sablier-labs/deployments/blob/main/flow/v1.1.0) |
 
 ### zKSync Sepolia
 

--- a/docs/guides/lockup/02-deployments.mdx
+++ b/docs/guides/lockup/02-deployments.mdx
@@ -387,13 +387,13 @@ Sablier repositories on Github.
 
 ### Taiko Hekla
 
-| Contract            | Address                                                                                                                       | Deployment                                                                    |
-| :------------------ | :---------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------- |
-| SablierLockup       | [0xa969f0CCc080dfd513Eb7175248df68364701fC2](https://sepolia.taikoscan.io/address/0xa969f0CCc080dfd513Eb7175248df68364701fC2) | [v2.0.0](https://github.com/sablier-labs/deployments/blob/main/lockup/v2.0.0) |
-| SablierBatchLockup  | [0x5F62Be3b60c3Dc3D49e96Ee8390Fea2930A3E01b](https://sepolia.taikoscan.io/address/0x5F62Be3b60c3Dc3D49e96Ee8390Fea2930A3E01b) | [v2.0.0](https://github.com/sablier-labs/deployments/blob/main/lockup/v2.0.0) |
-| LockupNFTDescriptor | [0x4a92Ca0a777fd781B3aA1d7925Ad54B64C85eedE](https://sepolia.taikoscan.io/address/0x4a92Ca0a777fd781B3aA1d7925Ad54B64C85eedE) | [v2.0.0](https://github.com/sablier-labs/deployments/blob/main/lockup/v2.0.0) |
-| Helpers             | [0xf8076E4Fb5cfE8be1C26E61222DC51828Db8C1dc](https://sepolia.taikoscan.io/address/0xf8076E4Fb5cfE8be1C26E61222DC51828Db8C1dc) | [v2.0.0](https://github.com/sablier-labs/deployments/blob/main/lockup/v2.0.0) |
-| VestingMath         | [0x5522CA06Ce080800AB59BA4C091e63f6f54C5E6d](https://sepolia.taikoscan.io/address/0x5522CA06Ce080800AB59BA4C091e63f6f54C5E6d) | [v2.0.0](https://github.com/sablier-labs/deployments/blob/main/lockup/v2.0.0) |
+| Contract            | Address                                                                                                                          | Deployment                                                                    |
+| :------------------ | :------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------- |
+| SablierLockup       | [0xa969f0CCc080dfd513Eb7175248df68364701fC2](https://hekla.taikoexplorer.com/address/0xa969f0CCc080dfd513Eb7175248df68364701fC2) | [v2.0.0](https://github.com/sablier-labs/deployments/blob/main/lockup/v2.0.0) |
+| SablierBatchLockup  | [0x5F62Be3b60c3Dc3D49e96Ee8390Fea2930A3E01b](https://hekla.taikoexplorer.com/address/0x5F62Be3b60c3Dc3D49e96Ee8390Fea2930A3E01b) | [v2.0.0](https://github.com/sablier-labs/deployments/blob/main/lockup/v2.0.0) |
+| LockupNFTDescriptor | [0x4a92Ca0a777fd781B3aA1d7925Ad54B64C85eedE](https://hekla.taikoexplorer.com/address/0x4a92Ca0a777fd781B3aA1d7925Ad54B64C85eedE) | [v2.0.0](https://github.com/sablier-labs/deployments/blob/main/lockup/v2.0.0) |
+| Helpers             | [0xf8076E4Fb5cfE8be1C26E61222DC51828Db8C1dc](https://hekla.taikoexplorer.com/address/0xf8076E4Fb5cfE8be1C26E61222DC51828Db8C1dc) | [v2.0.0](https://github.com/sablier-labs/deployments/blob/main/lockup/v2.0.0) |
+| VestingMath         | [0x5522CA06Ce080800AB59BA4C091e63f6f54C5E6d](https://hekla.taikoexplorer.com/address/0x5522CA06Ce080800AB59BA4C091e63f6f54C5E6d) | [v2.0.0](https://github.com/sablier-labs/deployments/blob/main/lockup/v2.0.0) |
 
 ### zkSync Sepolia
 


### PR DESCRIPTION
This PR adds the supported networks table in the documentation. The following changes have been made:

- Added networks: BNB Smart Chain, Blast, Chiliz Chain, Ethereum Sepolia, Gnosis, IoTeX, Lightlink, Linea, Mode, Morph, Optimism Sepolia, Polygon, Scroll, Superseed, Tangle, XDC, zkSync Era

These updates ensure that the documentation reflects the latest supported networks and provides accurate information for users.

Closes [Add a table with all the chains Sablier is available on](https://github.com/sablier-labs/docs/issues/260)