### PR TITLE
docs: Add new config column for linear, dynamic and tranched streams benchmark tables.

### DIFF
--- a/docs/guides/flow/04-gas-benchmarks.md
+++ b/docs/guides/flow/04-gas-benchmarks.md
@@ -17,17 +17,17 @@ that generates these benchmarks.
 
 The following gas benchmarks are generated using a 6-decimal token.
 
-| Function                      | Gas Usage |
-| ----------------------------- | --------- |
-| `adjustRatePerSecond`         | 44,171    |
-| `create`                      | 113,681   |
-| `deposit`                     | 32,975    |
-| `depositViaBroker`            | 22,732    |
-| `pause`                       | 7,522     |
-| `refund`                      | 11,939    |
-| `restart`                     | 7,036     |
-| `void (solvent stream)`       | 10,060    |
-| `void (insolvent stream)`     | 37,460    |
-| `withdraw (insolvent stream)` | 57,688    |
-| `withdraw (solvent stream)`   | 38,156    |
-| `withdrawMax`                 | 51,988    |
+| Function              | Stream Liquidity | Gas Usage |
+| --------------------- | ---------------- | --------- |
+| `adjustRatePerSecond` | N/A              | 44,171    |
+| `create`              | N/A              | 113,681   |
+| `deposit`             | N/A              | 32,975    |
+| `depositViaBroker`    | N/A              | 22,732    |
+| `pause`               | N/A              | 7,522     |
+| `refund`              | N/A              | 11,939    |
+| `restart`             | N/A              | 7,036     |
+| `void`                | Insolvent        | 37,460    |
+| `void`                | Solvent          | 10,060    |
+| `withdraw`            | Insolvent        | 57,688    |
+| `withdraw`            | Solvent          | 38,156    |
+| `withdrawMax`         | N/A              | 51,988    |

--- a/docs/guides/lockup/04-gas-benchmarks.md
+++ b/docs/guides/lockup/04-gas-benchmarks.md
@@ -52,7 +52,7 @@ that generates these benchmarks.
 
 ### Linear Stream
 
-| Function                 | Config                                       | Gas Usage |
+| Function                 | Configuration                                | Gas Usage |
 | ------------------------ | -------------------------------------------- | --------- |
 | `burn`                   | N/A                                          | 16,141    |
 | `cancel`                 | N/A                                          | 65,381    |
@@ -72,7 +72,7 @@ that generates these benchmarks.
 
 ### Dynamic Stream
 
-| Function                 | Segments | Config                                       | Gas Usage |
+| Function                 | Segments | Configuration                                | Gas Usage |
 | ------------------------ | -------- | -------------------------------------------- | --------- |
 | `burn`                   | N/A      | N/A                                          | 16,141    |
 | `cancel`                 | N/A      | N/A                                          | 65,381    |
@@ -104,7 +104,7 @@ that generates these benchmarks.
 
 ### Tranched Stream
 
-| Function                 | Tranches | Config                                       | Gas Usage |
+| Function                 | Tranches | Configuration                                | Gas Usage |
 | ------------------------ | -------- | -------------------------------------------- | --------- |
 | `burn`                   | N/A      | N/A                                          | 16,141    |
 | `cancel`                 | N/A      | N/A                                          | 65,381    |

--- a/docs/guides/lockup/04-gas-benchmarks.md
+++ b/docs/guides/lockup/04-gas-benchmarks.md
@@ -52,84 +52,84 @@ that generates these benchmarks.
 
 ### Linear Stream
 
-| Function                                                      | Gas Usage |
-| ------------------------------------------------------------- | --------- |
-| `burn`                                                        | 16,141    |
-| `cancel`                                                      | 65,381    |
-| `renounce`                                                    | 27,721    |
-| `createWithDurationsLL` (Broker fee set) (cliff not set)      | 138,649   |
-| `createWithDurationsLL` (Broker fee not set) (cliff not set)  | 122,287   |
-| `createWithDurationsLL` (Broker fee set) (cliff set)          | 169,335   |
-| `createWithDurationsLL` (Broker fee not set) (cliff set)      | 164,278   |
-| `createWithTimestampsLL` (Broker fee set) (cliff not set)     | 125,100   |
-| `createWithTimestampsLL` (Broker fee not set) (cliff not set) | 120,038   |
-| `createWithTimestampsLL` (Broker fee set) (cliff set)         | 169,682   |
-| `createWithTimestampsLL` (Broker fee not set) (cliff set)     | 164,614   |
-| `withdraw` (After End Time) (by Recipient)                    | 33,179    |
-| `withdraw` (Before End Time) (by Recipient)                   | 23,303    |
-| `withdraw` (After End Time) (by Anyone)                       | 29,561    |
-| `withdraw` (Before End Time) (by Anyone)                      | 22,815    |
+| Function                 | Config                               | Gas Usage |
+| ------------------------ | ------------------------------------ | --------- |
+| `burn`                   | N/A                                  | 16,141    |
+| `cancel`                 | N/A                                  | 65,381    |
+| `renounce`               | N/A                                  | 27,721    |
+| `createWithDurationsLL`  | (Broker fee set) (cliff not set)     | 138,649   |
+| `createWithDurationsLL`  | (Broker fee not set) (cliff not set) | 122,287   |
+| `createWithDurationsLL`  | (Broker fee set) (cliff set)         | 169,335   |
+| `createWithDurationsLL`  | (Broker fee not set) (cliff set)     | 164,278   |
+| `createWithTimestampsLL` | (Broker fee set) (cliff not set)     | 125,100   |
+| `createWithTimestampsLL` | (Broker fee not set) (cliff not set) | 120,038   |
+| `createWithTimestampsLL` | (Broker fee set) (cliff set)         | 169,682   |
+| `createWithTimestampsLL` | (Broker fee not set) (cliff set)     | 164,614   |
+| `withdraw`               | (After End Time) (by Recipient)      | 33,179    |
+| `withdraw`               | (Before End Time) (by Recipient)     | 23,303    |
+| `withdraw`               | (After End Time) (by Anyone)         | 29,561    |
+| `withdraw`               | (Before End Time) (by Anyone)        | 22,815    |
 
 ### Dynamic Stream
 
-| Function                                                     | Gas Usage |
-| ------------------------------------------------------------ | --------- |
-| `burn`                                                       | 16,141    |
-| `cancel`                                                     | 65,381    |
-| `renounce`                                                   | 27,721    |
-| `createWithDurationsLD` (2 segments) (Broker fee set)        | 216,788   |
-| `createWithDurationsLD` (2 segments) (Broker fee not set)    | 200,461   |
-| `createWithTimestampsLD` (2 segments) (Broker fee set)       | 197,652   |
-| `createWithTimestampsLD` (2 segments) (Broker fee not set)   | 192,627   |
-| `withdraw` (2 segments) (After End Time) (by Recipient)      | 23,885    |
-| `withdraw` (2 segments) (Before End Time) (by Recipient)     | 29,903    |
-| `withdraw` (2 segments) (After End Time) (by Anyone)         | 19,175    |
-| `withdraw` (2 segments) (Before End Time) (by Anyone)        | 29,992    |
-| `createWithDurationsLD` (10 segments) (Broker fee set)       | 422,199   |
-| `createWithDurationsLD` (10 segments) (Broker fee not set)   | 417,189   |
-| `createWithTimestampsLD` (10 segments) (Broker fee set)      | 402,125   |
-| `createWithTimestampsLD` (10 segments) (Broker fee not set)  | 397,126   |
-| `withdraw` (10 segments) (After End Time) (by Recipient)     | 24,167    |
-| `withdraw` (10 segments) (Before End Time) (by Recipient)    | 37,190    |
-| `withdraw` (10 segments) (After End Time) (by Anyone)        | 24,278    |
-| `withdraw` (10 segments) (Before End Time) (by Anyone)       | 37,279    |
-| `createWithDurationsLD` (100 segments) (Broker fee set)      | 2,898,563 |
-| `createWithDurationsLD` (100 segments) (Broker fee not set)  | 2,894,573 |
-| `createWithTimestampsLD` (100 segments) (Broker fee set)     | 2,706,641 |
-| `createWithTimestampsLD` (100 segments) (Broker fee not set) | 2,702,660 |
-| `withdraw` (100 segments) (After End Time) (by Recipient)    | 81,920    |
-| `withdraw` (100 segments) (Before End Time) (by Recipient)   | 119,603   |
-| `withdraw` (100 segments) (After End Time) (by Anyone)       | 82,009    |
-| `withdraw` (100 segments) (Before End Time) (by Anyone)      | 119,692   |
+| Function                 | Config                                          | Gas Usage |
+| ------------------------ | ----------------------------------------------- | --------- |
+| `burn`                   | [N/A]                                           | 16,141    |
+| `cancel`                 | [N/A]                                           | 65,381    |
+| `renounce`               | [N/A]                                           | 27,721    |
+| `createWithDurationsLD`  | (2 segments) (Broker fee set)                   | 216,788   |
+| `createWithDurationsLD`  | (2 segments) (Broker fee not set)               | 200,461   |
+| `createWithTimestampsLD` | (2 segments) (Broker fee set)                   | 197,652   |
+| `createWithTimestampsLD` | (2 segments) (Broker fee not set)               | 192,627   |
+| `withdraw`               | (2 segments) (After End Time) (by Recipient)    | 23,885    |
+| `withdraw`               | (2 segments) (Before End Time) (by Recipient)   | 29,903    |
+| `withdraw`               | (2 segments) (After End Time) (by Anyone)       | 19,175    |
+| `withdraw`               | (2 segments) (Before End Time) (by Anyone)      | 29,992    |
+| `createWithDurationsLD`  | (10 segments) (Broker fee set)                  | 422,199   |
+| `createWithDurationsLD`  | (10 segments) (Broker fee not set)              | 417,189   |
+| `createWithTimestampsLD` | (10 segments) (Broker fee set)                  | 402,125   |
+| `createWithTimestampsLD` | (10 segments) (Broker fee not set)              | 397,126   |
+| `withdraw`               | (10 segments) (After End Time) (by Recipient)   | 24,167    |
+| `withdraw`               | (10 segments) (Before End Time) (by Recipient)  | 37,190    |
+| `withdraw`               | (10 segments) (After End Time) (by Anyone)      | 24,278    |
+| `withdraw`               | (10 segments) (Before End Time) (by Anyone)     | 37,279    |
+| `createWithDurationsLD`  | (100 segments) (Broker fee set)                 | 2,898,563 |
+| `createWithDurationsLD`  | (100 segments) (Broker fee not set)             | 2,894,573 |
+| `createWithTimestampsLD` | (100 segments) (Broker fee set)                 | 2,706,641 |
+| `createWithTimestampsLD` | (100 segments) (Broker fee not set)             | 2,702,660 |
+| `withdraw`               | (100 segments) (After End Time) (by Recipient)  | 81,920    |
+| `withdraw`               | (100 segments) (Before End Time) (by Recipient) | 119,603   |
+| `withdraw`               | (100 segments) (After End Time) (by Anyone)     | 82,009    |
+| `withdraw`               | (100 segments) (Before End Time) (by Anyone)    | 119,692   |
 
 ### Tranched Stream
 
-| Function                                                     | Gas Usage |
-| ------------------------------------------------------------ | --------- |
-| `burn`                                                       | 16,141    |
-| `cancel`                                                     | 65,381    |
-| `renounce`                                                   | 27,721    |
-| `createWithDurationsLT` (2 tranches) (Broker fee set)        | 215,994   |
-| `createWithDurationsLT` (2 tranches) (Broker fee not set)    | 199,665   |
-| `createWithTimestampsLT` (2 tranches) (Broker fee set)       | 196,988   |
-| `createWithTimestampsLT` (2 tranches) (Broker fee not set)   | 191,964   |
-| `withdraw` (2 tranches) (After End Time) (by Recipient)      | 23,599    |
-| `withdraw` (2 tranches) (Before End Time) (by Recipient)     | 18,503    |
-| `withdraw` (2 tranches) (After End Time) (by Anyone)         | 18,889    |
-| `withdraw` (2 tranches) (Before End Time) (by Anyone)        | 18,592    |
-| `createWithDurationsLT` (10 tranches) (Broker fee set)       | 414,411   |
-| `createWithDurationsLT` (10 tranches) (Broker fee not set)   | 409,394   |
-| `createWithTimestampsLT` (10 tranches) (Broker fee set)      | 397,045   |
-| `createWithTimestampsLT` (10 tranches) (Broker fee not set)  | 392,026   |
-| `withdraw` (10 tranches) (After End Time) (by Recipient)     | 23,318    |
-| `withdraw` (10 tranches) (Before End Time) (by Recipient)    | 25,403    |
-| `withdraw` (10 tranches) (After End Time) (by Anyone)        | 23,427    |
-| `withdraw` (10 tranches) (Before End Time) (by Anyone)       | 25,492    |
-| `createWithDurationsLT` (100 tranches) (Broker fee set)      | 2,808,652 |
-| `createWithDurationsLT` (100 tranches) (Broker fee not set)  | 2,804,166 |
-| `createWithTimestampsLT` (100 tranches) (Broker fee set)     | 2,649,659 |
-| `createWithTimestampsLT` (100 tranches) (Broker fee not set) | 2,645,177 |
-| `withdraw` (100 tranches) (After End Time) (by Recipient)    | 74,530    |
-| `withdraw` (100 tranches) (Before End Time) (by Recipient)   | 103,255   |
-| `withdraw` (100 tranches) (After End Time) (by Anyone)       | 74,619    |
-| `withdraw` (100 tranches) (Before End Time) (by Anyone)      | 103,344   |
+| Function                 | Config                                          | Gas Usage |
+| ------------------------ | ----------------------------------------------- | --------- |
+| `burn`                   | N/A                                             | 16,141    |
+| `cancel`                 | N/A                                             | 65,381    |
+| `renounce`               | N/A                                             | 27,721    |
+| `createWithDurationsLT`  | (2 tranches) (Broker fee set)                   | 215,994   |
+| `createWithDurationsLT`  | (2 tranches) (Broker fee not set)               | 199,665   |
+| `createWithTimestampsLT` | (2 tranches) (Broker fee set)                   | 196,988   |
+| `createWithTimestampsLT` | (2 tranches) (Broker fee not set)               | 191,964   |
+| `withdraw`               | (2 tranches) (After End Time) (by Recipient)    | 23,599    |
+| `withdraw`               | (2 tranches) (Before End Time) (by Recipient)   | 18,503    |
+| `withdraw`               | (2 tranches) (After End Time) (by Anyone)       | 18,889    |
+| `withdraw`               | (2 tranches) (Before End Time) (by Anyone)      | 18,592    |
+| `createWithDurationsLT`  | (10 tranches) (Broker fee set)                  | 414,411   |
+| `createWithDurationsLT`  | (10 tranches) (Broker fee not set)              | 409,394   |
+| `createWithTimestampsLT` | (10 tranches) (Broker fee set)                  | 397,045   |
+| `createWithTimestampsLT` | (10 tranches) (Broker fee not set)              | 392,026   |
+| `withdraw`               | (10 tranches) (After End Time) (by Recipient)   | 23,318    |
+| `withdraw`               | (10 tranches) (Before End Time) (by Recipient)  | 25,403    |
+| `withdraw`               | (10 tranches) (After End Time) (by Anyone)      | 23,427    |
+| `withdraw`               | (10 tranches) (Before End Time) (by Anyone)     | 25,492    |
+| `createWithDurationsLT`  | (100 tranches) (Broker fee set)                 | 2,808,652 |
+| `createWithDurationsLT`  | (100 tranches) (Broker fee not set)             | 2,804,166 |
+| `createWithTimestampsLT` | (100 tranches) (Broker fee set)                 | 2,649,659 |
+| `createWithTimestampsLT` | (100 tranches) (Broker fee not set)             | 2,645,177 |
+| `withdraw`               | (100 tranches) (After End Time) (by Recipient)  | 74,530    |
+| `withdraw`               | (100 tranches) (Before End Time) (by Recipient) | 103,255   |
+| `withdraw`               | (100 tranches) (After End Time) (by Anyone)     | 74,619    |
+| `withdraw`               | (100 tranches) (Before End Time) (by Anyone)    | 103,344   |

--- a/docs/guides/lockup/04-gas-benchmarks.md
+++ b/docs/guides/lockup/04-gas-benchmarks.md
@@ -52,84 +52,84 @@ that generates these benchmarks.
 
 ### Linear Stream
 
-| Function                 | Config                               | Gas Usage |
-| ------------------------ | ------------------------------------ | --------- |
-| `burn`                   | N/A                                  | 16,141    |
-| `cancel`                 | N/A                                  | 65,381    |
-| `renounce`               | N/A                                  | 27,721    |
-| `createWithDurationsLL`  | (Broker fee set) (cliff not set)     | 138,649   |
-| `createWithDurationsLL`  | (Broker fee not set) (cliff not set) | 122,287   |
-| `createWithDurationsLL`  | (Broker fee set) (cliff set)         | 169,335   |
-| `createWithDurationsLL`  | (Broker fee not set) (cliff set)     | 164,278   |
-| `createWithTimestampsLL` | (Broker fee set) (cliff not set)     | 125,100   |
-| `createWithTimestampsLL` | (Broker fee not set) (cliff not set) | 120,038   |
-| `createWithTimestampsLL` | (Broker fee set) (cliff set)         | 169,682   |
-| `createWithTimestampsLL` | (Broker fee not set) (cliff set)     | 164,614   |
-| `withdraw`               | (After End Time) (by Recipient)      | 33,179    |
-| `withdraw`               | (Before End Time) (by Recipient)     | 23,303    |
-| `withdraw`               | (After End Time) (by Anyone)         | 29,561    |
-| `withdraw`               | (Before End Time) (by Anyone)        | 22,815    |
+| Function                 | Config                                       | Gas Usage |
+| ------------------------ | -------------------------------------------- | --------- |
+| `burn`                   | N/A                                          | 16,141    |
+| `cancel`                 | N/A                                          | 65,381    |
+| `renounce`               | N/A                                          | 27,721    |
+| `createWithDurationsLL`  | broker = 0 & cliff = 0                       | 122,287   |
+| `createWithDurationsLL`  | broker > 0 & cliff = 0                       | 138,649   |
+| `createWithDurationsLL`  | broker = 0 & cliff > 0                       | 164,278   |
+| `createWithDurationsLL`  | broker > 0 & cliff > 0                       | 169,335   |
+| `createWithTimestampsLL` | broker = 0 & cliff = 0                       | 120,038   |
+| `createWithTimestampsLL` | broker > 0 & cliff = 0                       | 125,100   |
+| `createWithTimestampsLL` | broker = 0 & cliff > 0                       | 164,614   |
+| `createWithTimestampsLL` | broker > 0 & cliff > 0                       | 169,682   |
+| `withdraw`               | endTime < blockTime & msgSender = recipient  | 33,179    |
+| `withdraw`               | endTime > blockTime & msgSender = recipient  | 23,303    |
+| `withdraw`               | endTime < blockTime & msgSender != recipient | 29,561    |
+| `withdraw`               | endTime > blockTime & msgSender != recipient | 22,815    |
 
 ### Dynamic Stream
 
-| Function                 | Config                                          | Gas Usage |
-| ------------------------ | ----------------------------------------------- | --------- |
-| `burn`                   | [N/A]                                           | 16,141    |
-| `cancel`                 | [N/A]                                           | 65,381    |
-| `renounce`               | [N/A]                                           | 27,721    |
-| `createWithDurationsLD`  | (2 segments) (Broker fee set)                   | 216,788   |
-| `createWithDurationsLD`  | (2 segments) (Broker fee not set)               | 200,461   |
-| `createWithTimestampsLD` | (2 segments) (Broker fee set)                   | 197,652   |
-| `createWithTimestampsLD` | (2 segments) (Broker fee not set)               | 192,627   |
-| `withdraw`               | (2 segments) (After End Time) (by Recipient)    | 23,885    |
-| `withdraw`               | (2 segments) (Before End Time) (by Recipient)   | 29,903    |
-| `withdraw`               | (2 segments) (After End Time) (by Anyone)       | 19,175    |
-| `withdraw`               | (2 segments) (Before End Time) (by Anyone)      | 29,992    |
-| `createWithDurationsLD`  | (10 segments) (Broker fee set)                  | 422,199   |
-| `createWithDurationsLD`  | (10 segments) (Broker fee not set)              | 417,189   |
-| `createWithTimestampsLD` | (10 segments) (Broker fee set)                  | 402,125   |
-| `createWithTimestampsLD` | (10 segments) (Broker fee not set)              | 397,126   |
-| `withdraw`               | (10 segments) (After End Time) (by Recipient)   | 24,167    |
-| `withdraw`               | (10 segments) (Before End Time) (by Recipient)  | 37,190    |
-| `withdraw`               | (10 segments) (After End Time) (by Anyone)      | 24,278    |
-| `withdraw`               | (10 segments) (Before End Time) (by Anyone)     | 37,279    |
-| `createWithDurationsLD`  | (100 segments) (Broker fee set)                 | 2,898,563 |
-| `createWithDurationsLD`  | (100 segments) (Broker fee not set)             | 2,894,573 |
-| `createWithTimestampsLD` | (100 segments) (Broker fee set)                 | 2,706,641 |
-| `createWithTimestampsLD` | (100 segments) (Broker fee not set)             | 2,702,660 |
-| `withdraw`               | (100 segments) (After End Time) (by Recipient)  | 81,920    |
-| `withdraw`               | (100 segments) (Before End Time) (by Recipient) | 119,603   |
-| `withdraw`               | (100 segments) (After End Time) (by Anyone)     | 82,009    |
-| `withdraw`               | (100 segments) (Before End Time) (by Anyone)    | 119,692   |
+| Function                 | Segments | Config                                       | Gas Usage |
+| ------------------------ | -------- | -------------------------------------------- | --------- |
+| `burn`                   | N/A      | N/A                                          | 16,141    |
+| `cancel`                 | N/A      | N/A                                          | 65,381    |
+| `renounce`               | N/A      | N/A                                          | 27,721    |
+| `createWithDurationsLD`  | 2        | broker = 0                                   | 200,461   |
+| `createWithDurationsLD`  | 2        | broker > 0                                   | 216,788   |
+| `createWithTimestampsLD` | 2        | broker = 0                                   | 192,627   |
+| `createWithTimestampsLD` | 2        | broker > 0                                   | 197,652   |
+| `withdraw`               | 2        | endTime < blockTime & msgSender = recipient  | 23,885    |
+| `withdraw`               | 2        | endTime > blockTime & msgSender = recipient  | 29,903    |
+| `withdraw`               | 2        | endTime < blockTime & msgSender != recipient | 19,175    |
+| `withdraw`               | 2        | endTime > blockTime & msgSender != recipient | 29,992    |
+| `createWithDurationsLD`  | 10       | broker = 0                                   | 417,189   |
+| `createWithDurationsLD`  | 10       | broker > 0                                   | 422,199   |
+| `createWithTimestampsLD` | 10       | broker = 0                                   | 397,126   |
+| `createWithTimestampsLD` | 10       | broker > 0                                   | 402,125   |
+| `withdraw`               | 10       | endTime < blockTime & msgSender = recipient  | 24,167    |
+| `withdraw`               | 10       | endTime > blockTime & msgSender = recipient  | 37,190    |
+| `withdraw`               | 10       | endTime < blockTime & msgSender != recipient | 24,278    |
+| `withdraw`               | 10       | endTime > blockTime & msgSender != recipient | 37,279    |
+| `createWithDurationsLD`  | 100      | broker = 0                                   | 2,894,573 |
+| `createWithDurationsLD`  | 100      | broker > 0                                   | 2,898,563 |
+| `createWithTimestampsLD` | 100      | broker = 0                                   | 2,702,660 |
+| `createWithTimestampsLD` | 100      | broker > 0                                   | 2,706,641 |
+| `withdraw`               | 100      | endTime < blockTime & msgSender = recipient  | 81,920    |
+| `withdraw`               | 100      | endTime > blockTime & msgSender = recipient  | 119,603   |
+| `withdraw`               | 100      | endTime < blockTime & msgSender != recipient | 82,009    |
+| `withdraw`               | 100      | endTime > blockTime & msgSender != recipient | 119,692   |
 
 ### Tranched Stream
 
-| Function                 | Config                                          | Gas Usage |
-| ------------------------ | ----------------------------------------------- | --------- |
-| `burn`                   | N/A                                             | 16,141    |
-| `cancel`                 | N/A                                             | 65,381    |
-| `renounce`               | N/A                                             | 27,721    |
-| `createWithDurationsLT`  | (2 tranches) (Broker fee set)                   | 215,994   |
-| `createWithDurationsLT`  | (2 tranches) (Broker fee not set)               | 199,665   |
-| `createWithTimestampsLT` | (2 tranches) (Broker fee set)                   | 196,988   |
-| `createWithTimestampsLT` | (2 tranches) (Broker fee not set)               | 191,964   |
-| `withdraw`               | (2 tranches) (After End Time) (by Recipient)    | 23,599    |
-| `withdraw`               | (2 tranches) (Before End Time) (by Recipient)   | 18,503    |
-| `withdraw`               | (2 tranches) (After End Time) (by Anyone)       | 18,889    |
-| `withdraw`               | (2 tranches) (Before End Time) (by Anyone)      | 18,592    |
-| `createWithDurationsLT`  | (10 tranches) (Broker fee set)                  | 414,411   |
-| `createWithDurationsLT`  | (10 tranches) (Broker fee not set)              | 409,394   |
-| `createWithTimestampsLT` | (10 tranches) (Broker fee set)                  | 397,045   |
-| `createWithTimestampsLT` | (10 tranches) (Broker fee not set)              | 392,026   |
-| `withdraw`               | (10 tranches) (After End Time) (by Recipient)   | 23,318    |
-| `withdraw`               | (10 tranches) (Before End Time) (by Recipient)  | 25,403    |
-| `withdraw`               | (10 tranches) (After End Time) (by Anyone)      | 23,427    |
-| `withdraw`               | (10 tranches) (Before End Time) (by Anyone)     | 25,492    |
-| `createWithDurationsLT`  | (100 tranches) (Broker fee set)                 | 2,808,652 |
-| `createWithDurationsLT`  | (100 tranches) (Broker fee not set)             | 2,804,166 |
-| `createWithTimestampsLT` | (100 tranches) (Broker fee set)                 | 2,649,659 |
-| `createWithTimestampsLT` | (100 tranches) (Broker fee not set)             | 2,645,177 |
-| `withdraw`               | (100 tranches) (After End Time) (by Recipient)  | 74,530    |
-| `withdraw`               | (100 tranches) (Before End Time) (by Recipient) | 103,255   |
-| `withdraw`               | (100 tranches) (After End Time) (by Anyone)     | 74,619    |
-| `withdraw`               | (100 tranches) (Before End Time) (by Anyone)    | 103,344   |
+| Function                 | Tranches | Config                                       | Gas Usage |
+| ------------------------ | -------- | -------------------------------------------- | --------- |
+| `burn`                   | N/A      | N/A                                          | 16,141    |
+| `cancel`                 | N/A      | N/A                                          | 65,381    |
+| `renounce`               | N/A      | N/A                                          | 27,721    |
+| `createWithDurationsLT`  | 2        | broker = 0                                   | 199,665   |
+| `createWithDurationsLT`  | 2        | broker > 0                                   | 215,994   |
+| `createWithTimestampsLT` | 2        | broker = 0                                   | 191,964   |
+| `createWithTimestampsLT` | 2        | broker > 0                                   | 196,988   |
+| `withdraw`               | 2        | endTime < blockTime & msgSender = recipient  | 23,599    |
+| `withdraw`               | 2        | endTime > blockTime & msgSender = recipient  | 18,503    |
+| `withdraw`               | 2        | endTime < blockTime & msgSender != recipient | 18,889    |
+| `withdraw`               | 2        | endTime > blockTime & msgSender != recipient | 18,592    |
+| `createWithDurationsLT`  | 10       | broker = 0                                   | 409,394   |
+| `createWithDurationsLT`  | 10       | broker > 0                                   | 414,411   |
+| `createWithTimestampsLT` | 10       | broker = 0                                   | 392,026   |
+| `createWithTimestampsLT` | 10       | broker > 0                                   | 397,045   |
+| `withdraw`               | 10       | endTime < blockTime & msgSender = recipient  | 23,318    |
+| `withdraw`               | 10       | endTime > blockTime & msgSender = recipient  | 25,403    |
+| `withdraw`               | 10       | endTime < blockTime & msgSender != recipient | 23,427    |
+| `withdraw`               | 10       | endTime > blockTime & msgSender != recipient | 25,492    |
+| `createWithDurationsLT`  | 100      | broker = 0                                   | 2,804,166 |
+| `createWithDurationsLT`  | 100      | broker > 0                                   | 2,808,652 |
+| `createWithTimestampsLT` | 100      | broker = 0                                   | 2,645,177 |
+| `createWithTimestampsLT` | 100      | broker > 0                                   | 2,649,659 |
+| `withdraw`               | 100      | endTime < blockTime & msgSender = recipient  | 74,530    |
+| `withdraw`               | 100      | endTime > blockTime & msgSender = recipient  | 103,255   |
+| `withdraw`               | 100      | endTime < blockTime & msgSender != recipient | 74,619    |
+| `withdraw`               | 100      | endTime > blockTime & msgSender != recipient | 103,344   |


### PR DESCRIPTION
Adds a config column to the benchmark tables

closes [Add new "config" column for benchmark tables](https://github.com/sablier-labs/docs/issues/270)