### PR TITLE
docs: updates references to the benchmark code.

### DIFF
--- a/docs/concepts/lockup/02-stream-shapes.mdx
+++ b/docs/concepts/lockup/02-stream-shapes.mdx
@@ -9,7 +9,7 @@ import FunctionPlot from "@site/src/components/FunctionPlot";
 :::note
 
 - The code used to generate the gas benchmarks for the different stream curves can be found
-  [here](https://github.com/sablier-labs/examples/tree/shapes-benchmark).
+  [here](https://github.com/sablier-labs/benchmarks).
 
 - If you are interested in learning how to programmatically create the curves shown below in Solidity, check out the
   [examples](https://github.com/sablier-labs/examples/blob/main/lockup/) repository and the "CurvesCreator" files.

--- a/docs/concepts/lockup/02-stream-shapes.mdx
+++ b/docs/concepts/lockup/02-stream-shapes.mdx
@@ -9,7 +9,7 @@ import FunctionPlot from "@site/src/components/FunctionPlot";
 :::note
 
 - The code used to generate the gas benchmarks for the different stream curves can be found
-  [here](https://github.com/sablier-labs/benchmarks).
+  [here](https://github.com/sablier-labs/examples/tree/shapes-benchmark).
 
 - If you are interested in learning how to programmatically create the curves shown below in Solidity, check out the
   [examples](https://github.com/sablier-labs/examples/blob/main/lockup/) repository and the "CurvesCreator" files.

--- a/docs/guides/flow/04-gas-benchmarks.md
+++ b/docs/guides/flow/04-gas-benchmarks.md
@@ -10,8 +10,8 @@ mainnet - you shouldn't take them for granted. The gas usage may vary depending 
 
 :::note
 
-Please refer to the [GitHub repository](https://github.com/sablier-labs/flow/tree/release/benchmark) to view the code
-that generates these benchmarks.
+Please refer to the [GitHub repository](https://github.com/sablier-labs/benchmarks) to view the code that generates
+these benchmarks.
 
 :::
 

--- a/docs/guides/lockup/04-gas-benchmarks.md
+++ b/docs/guides/lockup/04-gas-benchmarks.md
@@ -10,8 +10,8 @@ mainnet - you shouldn't take them for granted. The gas usage may vary depending 
 
 :::note
 
-Please refer to the [GitHub repository](https://github.com/sablier-labs/lockup/tree/release/benchmark) to view the code
-that generates these benchmarks.
+Please refer to the [GitHub repository](https://github.com/sablier-labs/benchmarks) to view the code that generates
+these benchmarks.
 
 :::
 


### PR DESCRIPTION
closes [Refer to benchmarks repo for gas reference](https://github.com/sablier-labs/docs/issues/256)