### PR TITLE
Moves non-gas Q&A to new section.

### DIFF
--- a/docs/concepts/12-fees.mdx
+++ b/docs/concepts/12-fees.mdx
@@ -117,6 +117,21 @@ The fee is ~**$1** (in the gas token) per claim, regardless of the airdrop amoun
 
 ## Gas Fees
 
+### Q: What are gas fees?
+
+A: [Gas fees](https://investopedia.com/terms/g/gas-ethereum.asp) are transaction fees paid to the blockchain validators
+in the gas token of the network, e.g., ETH. Sablier Labs does not take any cut from this.
+
+### Q: When are gas fees paid?
+
+A: Gas is paid only when streams are created, canceled, transferred, or withdrawn from. Gas is not accrued in real-time.
+
+### Q: Does Sablier receive any portion of the gas fee?
+
+A: No. 100% of the gas fee goes to the blockchain network validators, which are not affiliated with Sablier Labs.
+
+## FAQ
+
 ### Q: How are the Interface Fees charged?
 
 A: They are added to the gas fee. For example, if the gas fee is \$10 and the Interface Fee is \$1, you would pay \$11
@@ -131,19 +146,6 @@ higher of the two fees.
 
 A: Yes. The fee is charged each time you withdraw from a stream. For example, if you withdraw from a stream 10 times,
 you will pay $10 in fees.
-
-### Q: What are gas fees?
-
-A: [Gas fees](https://investopedia.com/terms/g/gas-ethereum.asp) are transaction fees paid to the blockchain validators
-in the gas token of the network, e.g., ETH. Sablier Labs does not take any cut from this.
-
-### Q: When are gas fees paid?
-
-A: Gas is paid only when streams are created, canceled, transferred, or withdrawn from. Gas is not accrued in real-time.
-
-### Q: Does Sablier receive any portion of the gas fee?
-
-A: No. 100% of the gas fee goes to the blockchain network validators, which are not affiliated with Sablier Labs.
 
 :::tip
 

--- a/docs/concepts/12-fees.mdx
+++ b/docs/concepts/12-fees.mdx
@@ -117,18 +117,13 @@ The fee is ~**$1** (in the gas token) per claim, regardless of the airdrop amoun
 
 ## Gas Fees
 
-### Q: What are gas fees?
+[Gas fees](https://investopedia.com/terms/g/gas-ethereum.asp) are transaction fees paid to the blockchain validators in
+the native token of the network, e.g., ETH for Ethereum Mainnet.
 
-A: [Gas fees](https://investopedia.com/terms/g/gas-ethereum.asp) are transaction fees paid to the blockchain validators
-in the gas token of the network, e.g., ETH. Sablier Labs does not take any cut from this.
+Gas is paid only when streams are created, canceled, transferred, or withdrawn from. Gas does not accrue in real-time.
 
-### Q: When are gas fees paid?
-
-A: Gas is paid only when streams are created, canceled, transferred, or withdrawn from. Gas is not accrued in real-time.
-
-### Q: Does Sablier receive any portion of the gas fee?
-
-A: No. 100% of the gas fee goes to the blockchain network validators, which are not affiliated with Sablier Labs.
+Importantly, Sablier Labs does not take any cut from the gas fee. 100% of the gas fee goes to the blockchain network
+validators, which are not affiliated with Sablier Labs.
 
 ## FAQ
 


### PR DESCRIPTION
The first 3 questions in the Gas Fees section are not about gas fees, which can cause confusion to readers.  I moved them to a new FAQ section, but there may be a better way to handle this.

One question is about how Interface and Contract fees interact, so it doesn't seem quite right for either section.  One is a Q&A about Interface fees specifically so it could be moved into that section, but currently that section is not in Q&A form.

It is also worth noting that the Gas Fees section is in Q&A format while the other two sections are in a more prose-like format, it may be worth making the Gas Fees section format match the Interface and Contract fees sections in writing style.