### PR TITLE
docs: update airdrops fee

### DIFF
--- a/docs/concepts/12-fees.mdx
+++ b/docs/concepts/12-fees.mdx
@@ -35,7 +35,7 @@ The Sablier Interface charges a flat fee when you claim an airdrop.
 
 :::tip[What is the claim fee?]
 
-The fee is **$3** (in the gas token) per claim, regardless of the airdrop amount.
+The fee is **$2** (in the gas token) per claim, regardless of the airdrop amount.
 
 :::
 
@@ -46,9 +46,10 @@ versions do not incur any claim fee.
 
 | Product  | Timeline                   | Operation     | Fee |
 | -------- | -------------------------- | ------------- | --- |
-| Airdrops | Feb 3, 2025 - present      | Airdrop claim | $3  |
+| Airdrops | Apr 10, 2025 - present     | Airdrop claim | $2  |
 | Lockup   | Feb 3, 2025 - present      | Withdraw      | $1  |
 | Flow     | Feb 3, 2025 - present      | Withdraw      | $1  |
+| Airdrops | Feb 3, 2025 - Apr 10, 2025 | Airdrop claim | $3  |
 | Airdrops | Dec 18, 2023 - Feb 2, 2025 | Airdrop claim | 0   |
 | Lockup   | Jul 3, 2023 - Feb 2, 2025  | Withdraw      | 0   |
 | Flow     | Dec 4, 2024 - Feb 2, 2025  | Withdraw      | 0   |


### PR DESCRIPTION
Closes https://github.com/sablier-labs/docs/issues/298

I could have replaced the old fee, but I thought it would nice to show it s a timeline. As the table grows, we will find a better way to display the same.

<img width="398" alt="Screenshot 2025-04-10 at 19 58 24" src="https://github.com/user-attachments/assets/25ef0d7b-6b1b-4604-9240-bed4e121dbeb" />
