### PR TITLE
fix: update incorrect URLs for previous endpoints

### DIFF
--- a/docs/api/airdrops/06-previous-endpoints.mdx
+++ b/docs/api/airdrops/06-previous-endpoints.mdx
@@ -35,55 +35,55 @@ import DeprecatedEndpoints from "@site/docs/snippets/DeprecatedEndpoints.mdx";
 
 [v2-network-ms-arbitrum]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/CPCMKbUFEM8CzVbfic1y34qKbTrKADX9Du9QxsAMAwqU
 [v2-explorer-ms-arbitrum]: https://thegraph.com/explorer/subgraphs/CPCMKbUFEM8CzVbfic1y34qKbTrKADX9Du9QxsAMAwqU
-[v2-studio-ms-arbitrum]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-arbitrum/version/latest
+[v2-studio-ms-arbitrum]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-arbitrum/version/latest
 
 {/* Chain: Arbitrum Sepolia */}
 
 [v2-network-ms-arbitrum-sepolia]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/BBJgy9RANbViGedeWTrVpH2bwm22E3niEzWcqHPMGtna
 [v2-explorer-ms-arbitrum-sepolia]: https://thegraph.com/explorer/subgraphs/BBJgy9RANbViGedeWTrVpH2bwm22E3niEzWcqHPMGtna
-[v2-studio-ms-arbitrum-sepolia]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-arbitrum-sepolia/version/latest
+[v2-studio-ms-arbitrum-sepolia]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-arbitrum-sepolia/version/latest
 
 {/* Chain: Avalanche */}
 
 [v2-network-ms-avalanche]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/2beDuAvmwbyFzJ95HAwfqNjnYT6nEnzbEfSNhfWGMyhJ
 [v2-explorer-ms-avalanche]: https://thegraph.com/explorer/subgraphs/2beDuAvmwbyFzJ95HAwfqNjnYT6nEnzbEfSNhfWGMyhJ
-[v2-studio-ms-avalanche]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-avalanche/version/latest
+[v2-studio-ms-avalanche]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-avalanche/version/latest
 
 {/* Chain: Base */}
 
 [v2-network-ms-base]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/DrfN5cbvcCmpQUSc5RE9T1UxtcnMREi1Rd2PgLzDZCo3
 [v2-explorer-ms-base]: https://thegraph.com/explorer/subgraphs/DrfN5cbvcCmpQUSc5RE9T1UxtcnMREi1Rd2PgLzDZCo3
-[v2-studio-ms-base]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-base/version/latest
+[v2-studio-ms-base]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-base/version/latest
 
 {/* Chain: Blast */}
 
 [v2-network-ms-blast]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/HVqkPvCRAvbxjx6YVmkk6w6rHPrqqtiymcGiQiMKPw8f
 [v2-explorer-ms-blast]: https://thegraph.com/explorer/subgraphs/HVqkPvCRAvbxjx6YVmkk6w6rHPrqqtiymcGiQiMKPw8f
-[v2-studio-ms-blast]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-blast/version/latest
+[v2-studio-ms-blast]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-blast/version/latest
 
 {/* Chain: BSC */}
 
 [v2-network-ms-bsc]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/8uU9qAw9fSzdjqebymGRXWCjtZ5DQCmUA6QzRA14ARpz
 [v2-explorer-ms-bsc]: https://thegraph.com/explorer/subgraphs/8uU9qAw9fSzdjqebymGRXWCjtZ5DQCmUA6QzRA14ARpz
-[v2-studio-ms-bsc]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-bsc/version/latest
+[v2-studio-ms-bsc]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-bsc/version/latest
 
 {/* Chain: Chiliz */}
 
 [v2-network-ms-chiliz]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/DdhRyXwhvEmKyioCk41m6Xu9fyaprsnp4gMWZ3bHYZJd
 [v2-explorer-ms-chiliz]: https://thegraph.com/explorer/subgraphs/DdhRyXwhvEmKyioCk41m6Xu9fyaprsnp4gMWZ3bHYZJd
-[v2-studio-ms-chiliz]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-chiliz/version/latest
+[v2-studio-ms-chiliz]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-chiliz/version/latest
 
 {/* Chain: Ethereum Sepolia */}
 
 [v2-network-ms-sepolia]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/8UVeHt7rHA27XZhViugaW4nStiN332dHTDWVTNBLCqPc
 [v2-explorer-ms-sepolia]: https://thegraph.com/explorer/subgraphs/8UVeHt7rHA27XZhViugaW4nStiN332dHTDWVTNBLCqPc
-[v2-studio-ms-sepolia]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-sepolia/version/latest
+[v2-studio-ms-sepolia]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-sepolia/version/latest
 
 {/* Chain: Gnosis */}
 
 [v2-network-ms-gnosis]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/FViBHgu2TtaZZXspDBzACjuPYKtqVDysmH35pk3W3zJJ
 [v2-explorer-ms-gnosis]: https://thegraph.com/explorer/subgraphs/FViBHgu2TtaZZXspDBzACjuPYKtqVDysmH35pk3W3zJJ
-[v2-studio-ms-gnosis]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-gnosis/version/latest
+[v2-studio-ms-gnosis]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-gnosis/version/latest
 
 {/* Chain: Lightlink */}
 
@@ -93,38 +93,38 @@ import DeprecatedEndpoints from "@site/docs/snippets/DeprecatedEndpoints.mdx";
 {/* Chain: Mainnet | Ethereum */}
 
 [v2-explorer-ms-ethereum]: https://thegraph.com/explorer/subgraphs/FigCYTmdPtXbf4tgNiy5ZrtnYefz92hsMcwM4f9N5ZeZ
-[v2-studio-ms-ethereum]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms/version/latest
+[v2-studio-ms-ethereum]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms/version/latest
 [v2-network-ms-ethereum]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/FigCYTmdPtXbf4tgNiy5ZrtnYefz92hsMcwM4f9N5ZeZ
 
 {/* Chain: Optimism */}
 
 [v2-network-ms-optimism]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/7iSmF69W4mQqtx6EfWXXn5s27Hrdh72etsPKVC9iE62U
 [v2-explorer-ms-optimism]: https://thegraph.com/explorer/subgraphs/7iSmF69W4mQqtx6EfWXXn5s27Hrdh72etsPKVC9iE62U
-[v2-studio-ms-optimism]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-optimism/version/latest
+[v2-studio-ms-optimism]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-optimism/version/latest
 
 {/* Chain: Optimism Sepolia */}
 
 [v2-network-ms-optimism-sepolia]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/CG5QddHKoABuN6KHZHYTHL7upg2iPTMYxi35Ey7jspkX
 [v2-explorer-ms-optimism-sepolia]: https://thegraph.com/explorer/subgraphs/CG5QddHKoABuN6KHZHYTHL7upg2iPTMYxi35Ey7jspkX
-[v2-studio-ms-optimism-sepolia]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-optimism-sepolia/version/latest
+[v2-studio-ms-optimism-sepolia]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-optimism-sepolia/version/latest
 
 {/* Chain: Polygon */}
 
 [v2-network-ms-polygon]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/4r2pC3iyLbzytNa5phat3SWdMEyXG8fmnf1K89D7zP2G
 [v2-explorer-ms-polygon]: https://thegraph.com/explorer/subgraphs/4r2pC3iyLbzytNa5phat3SWdMEyXG8fmnf1K89D7zP2G
-[v2-studio-ms-polygon]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-polygon/version/latest
+[v2-studio-ms-polygon]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-polygon/version/latest
 
 {/* Chain: Scroll */}
 
 [v2-network-ms-scroll]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/F1QnrgBpsVKtiVzkLisEC2PDo6cjzLoAy5HhPdFRdjW
 [v2-explorer-ms-scroll]: https://thegraph.com/explorer/subgraphs/F1QnrgBpsVKtiVzkLisEC2PDo6cjzLoAy5HhPdFRdjW
-[v2-studio-ms-scroll]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-scroll/version/latest
+[v2-studio-ms-scroll]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-scroll/version/latest
 
 {/* Chain: zkSync */}
 
 [v2-network-ms-zksync]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/BboiKY7JCdznoqurdXRizL9UYD1YdQKajaj4gvUrPPEA
 [v2-explorer-ms-zksync]: https://thegraph.com/explorer/subgraphs/BboiKY7JCdznoqurdXRizL9UYD1YdQKajaj4gvUrPPEA
-[v2-studio-ms-zksync]: https://api.studio.thegraph.com/query/112500/sablier-v2-ms-zksync/version/latest
+[v2-studio-ms-zksync]: https://api.studio.thegraph.com/query/57079/sablier-v2-ms-zksync/version/latest
 
 {/* --------------------------------------------------------------------------------------------------------------------------------- */}
 

--- a/docs/api/flow/05-previous-endpoints.mdx
+++ b/docs/api/flow/05-previous-endpoints.mdx
@@ -37,55 +37,55 @@ import DeprecatedEndpoints from "@site/docs/snippets/DeprecatedEndpoints.mdx";
 
 [v2-flow-network-arbitrum]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/61wTsPJr76vzcaMMrqQq7RkHSUsQmHoqiJbkFc1iaNN1
 [v2-flow-explorer-arbitrum]: https://thegraph.com/explorer/subgraphs/61wTsPJr76vzcaMMrqQq7RkHSUsQmHoqiJbkFc1iaNN1
-[v2-flow-studio-arbitrum]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-arbitrum/version/latest
+[v2-flow-studio-arbitrum]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-arbitrum/version/latest
 
 {/* Chain: Arbitrum Sepolia */}
 
 [v2-flow-network-arbitrum-sepolia]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/Ai8sJzb4W6B19kPzqWxe47R29YGw5dACy9AJ97nZzm5W
 [v2-flow-explorer-arbitrum-sepolia]: https://thegraph.com/explorer/subgraphs/Ai8sJzb4W6B19kPzqWxe47R29YGw5dACy9AJ97nZzm5W
-[v2-flow-studio-arbitrum-sepolia]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-arbitrum-sepolia/version/latest
+[v2-flow-studio-arbitrum-sepolia]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-arbitrum-sepolia/version/latest
 
 {/* Chain: Avalanche */}
 
 [v2-flow-network-avalanche]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/CUFanZFBBAaKcJDPLnCwWjo6gAruG92DcK38Y2PzARH8
 [v2-flow-explorer-avalanche]: https://thegraph.com/explorer/subgraphs/CUFanZFBBAaKcJDPLnCwWjo6gAruG92DcK38Y2PzARH8
-[v2-flow-studio-avalanche]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-avalanche/version/latest
+[v2-flow-studio-avalanche]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-avalanche/version/latest
 
 {/* Chain: Base */}
 
 [v2-flow-network-base]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/DVuHKeqguX339rd6JGav7wjXBVi5R4qneHSDNu1urTKr
 [v2-flow-explorer-base]: https://thegraph.com/explorer/subgraphs/DVuHKeqguX339rd6JGav7wjXBVi5R4qneHSDNu1urTKr
-[v2-flow-studio-base]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-base/version/latest
+[v2-flow-studio-base]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-base/version/latest
 
 {/* Chain: Blast */}
 
 [v2-flow-network-blast]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/84gjGqyeWDG2VxvRTRjTFxrnPMuZhAYF4iETBox2ix5D
 [v2-flow-explorer-blast]: https://thegraph.com/explorer/subgraphs/84gjGqyeWDG2VxvRTRjTFxrnPMuZhAYF4iETBox2ix5D
-[v2-flow-studio-blast]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-blast/version/latest
+[v2-flow-studio-blast]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-blast/version/latest
 
 {/* Chain: BSC */}
 
 [v2-flow-network-bsc]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/GJvqaYwX9vGXPXDFrANs6LcDALcN22bjvvPvrcNvU8rn
 [v2-flow-explorer-bsc]: https://thegraph.com/explorer/subgraphs/GJvqaYwX9vGXPXDFrANs6LcDALcN22bjvvPvrcNvU8rn
-[v2-flow-studio-bsc]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-bsc/version/latest
+[v2-flow-studio-bsc]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-bsc/version/latest
 
 {/* Chain: Chiliz */}
 
 [v2-flow-network-chiliz]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/H5LERpVjK2ugD42PX774kv5shHfqd13HkBPWtASq75L4
 [v2-flow-explorer-chiliz]: https://thegraph.com/explorer/subgraphs/H5LERpVjK2ugD42PX774kv5shHfqd13HkBPWtASq75L4
-[v2-flow-studio-chiliz]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-chiliz/version/latest
+[v2-flow-studio-chiliz]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-chiliz/version/latest
 
 {/* Chain: Gnosis */}
 
 [v2-flow-network-gnosis]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/3XxHfFUMixMJTGVn1FJFFER1NFYpDDQo4QAbR2sQSpAH
 [v2-flow-explorer-gnosis]: https://thegraph.com/explorer/subgraphs/3XxHfFUMixMJTGVn1FJFFER1NFYpDDQo4QAbR2sQSpAH
-[v2-flow-studio-gnosis]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-gnosis/version/latest
+[v2-flow-studio-gnosis]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-gnosis/version/latest
 
 {/* Chain: Linea */}
 
 [v2-flow-network-linea]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/25Ry5DsjAKLXh6b8uXSu6H85Jk9d3MHxQbpDUJTstwvx
 [v2-flow-explorer-linea]: https://thegraph.com/explorer/subgraphs/25Ry5DsjAKLXh6b8uXSu6H85Jk9d3MHxQbpDUJTstwvx
-[v2-flow-studio-linea]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-linea/version/latest
+[v2-flow-studio-linea]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-linea/version/latest
 
 {/* Chain: Lightlink */}
 
@@ -95,50 +95,50 @@ import DeprecatedEndpoints from "@site/docs/snippets/DeprecatedEndpoints.mdx";
 {/* Chain: Mainnet | Ethereum */}
 
 [v2-flow-explorer-ethereum]: https://thegraph.com/explorer/subgraphs/DgXaXAUMFTZdwo1aZ21dmGV2vyU1Wdb1DkHyVmy3y7xi
-[v2-flow-studio-ethereum]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl/version/latest
+[v2-flow-studio-ethereum]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl/version/latest
 [v2-flow-network-ethereum]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/DgXaXAUMFTZdwo1aZ21dmGV2vyU1Wdb1DkHyVmy3y7xi
 
 {/* Chain: Mode */}
 
 [v2-flow-network-mode]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/H9D24a58cCZmzZTnu4VNdUoFCEMhNYjHP9uohXr9Qi65
 [v2-flow-explorer-mode]: https://thegraph.com/explorer/subgraphs/H9D24a58cCZmzZTnu4VNdUoFCEMhNYjHP9uohXr9Qi65
-[v2-flow-studio-mode]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-mode/version/latest
+[v2-flow-studio-mode]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-mode/version/latest
 
 {/* Chain: Optimism */}
 
 [v2-flow-network-optimism]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/JAf9rM9bn6Z91htddJ33JAyrWdNXHmseHhvx11Bpfysg
 [v2-flow-explorer-optimism]: https://thegraph.com/explorer/subgraphs/JAf9rM9bn6Z91htddJ33JAyrWdNXHmseHhvx11Bpfysg
-[v2-flow-studio-optimism]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-optimism/version/latest
+[v2-flow-studio-optimism]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-optimism/version/latest
 
 {/* Chain: Optimism Sepolia */}
 
 [v2-flow-network-optimism-sepolia]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/5tosMw7VVdE9ie3Z8Hdz6Y4SqaMaKrBb3XnM9rTYUag2
 [v2-flow-explorer-optimism-sepolia]: https://thegraph.com/explorer/subgraphs/5tosMw7VVdE9ie3Z8Hdz6Y4SqaMaKrBb3XnM9rTYUag2
-[v2-flow-studio-optimism-sepolia]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-optimism-sepolia/version/latest
+[v2-flow-studio-optimism-sepolia]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-optimism-sepolia/version/latest
 
 {/* Chain: Polygon */}
 
 [v2-flow-network-polygon]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/G49hZr29bZK7TAa7KK8z4sZ3ZkL93Ss6CZDG6ffCSifV
 [v2-flow-explorer-polygon]: https://thegraph.com/explorer/subgraphs/G49hZr29bZK7TAa7KK8z4sZ3ZkL93Ss6CZDG6ffCSifV
-[v2-flow-studio-polygon]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-polygon/version/latest
+[v2-flow-studio-polygon]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-polygon/version/latest
 
 {/* Chain: Scroll */}
 
 [v2-flow-network-scroll]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/2d1uvMnHnohZowpGwDdj6Gpk5gT8SNcZjbLfTA3JVRa8
 [v2-flow-explorer-scroll]: https://thegraph.com/explorer/subgraphs/2d1uvMnHnohZowpGwDdj6Gpk5gT8SNcZjbLfTA3JVRa8
-[v2-flow-studio-scroll]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-scroll/version/latest
+[v2-flow-studio-scroll]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-scroll/version/latest
 
 {/* Chain: Ethereum Sepolia */}
 
 [v2-flow-network-sepolia]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/iYRc4ETBqkeiyVhMeXktJ9jxEuQhQ1eJb2Bv68mGkQm
 [v2-flow-explorer-sepolia]: https://thegraph.com/explorer/subgraphs/iYRc4ETBqkeiyVhMeXktJ9jxEuQhQ1eJb2Bv68mGkQm
-[v2-flow-studio-sepolia]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-sepolia/version/latest
+[v2-flow-studio-sepolia]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-sepolia/version/latest
 
 {/* Chain: zkSync */}
 
 [v2-flow-network-zksync]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/iYRc4ETBqkeiyVhMeXktJ9jxEuQhQ1eJb2Bv68mGkQm
 [v2-flow-explorer-zksync]: https://thegraph.com/explorer/subgraphs/iYRc4ETBqkeiyVhMeXktJ9jxEuQhQ1eJb2Bv68mGkQm
-[v2-flow-studio-zksync]: https://api.studio.thegraph.com/query/112500/sablier-v2-fl-zksync/version/latest
+[v2-flow-studio-zksync]: https://api.studio.thegraph.com/query/57079/sablier-v2-fl-zksync/version/latest
 
 {/* --------------------------------------------------------------------------------------------------------------------------------- */}
 

--- a/docs/api/lockup/05-previous-endpoints.mdx
+++ b/docs/api/lockup/05-previous-endpoints.mdx
@@ -35,49 +35,49 @@ import DeprecatedEndpoints from "@site/docs/snippets/DeprecatedEndpoints.mdx";
 
 [v2-network-arbitrum]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/8BnGPBojHycDxVo83LP468pUo4xDyCQbtTpHGZXR6SiB
 [v2-explorer-arbitrum]: https://thegraph.com/explorer/subgraphs/8BnGPBojHycDxVo83LP468pUo4xDyCQbtTpHGZXR6SiB
-[v2-studio-arbitrum]: https://api.studio.thegraph.com/query/112500/sablier-v2-arbitrum/version/latest
+[v2-studio-arbitrum]: https://api.studio.thegraph.com/query/57079/sablier-v2-arbitrum/version/latest
 
 {/* Chain: Arbitrum Sepolia */}
 
 [v2-network-arbitrum-sepolia]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/BZYXgTYGe51dy5rW6LhrLN7PWSiAgRQoqSBJEiPpRN9K
 [v2-explorer-arbitrum-sepolia]: https://thegraph.com/explorer/subgraphs/BZYXgTYGe51dy5rW6LhrLN7PWSiAgRQoqSBJEiPpRN9K
-[v2-studio-arbitrum-sepolia]: https://api.studio.thegraph.com/query/112500/sablier-v2-arbitrum-sepolia/version/latest
+[v2-studio-arbitrum-sepolia]: https://api.studio.thegraph.com/query/57079/sablier-v2-arbitrum-sepolia/version/latest
 
 {/* Chain: Avalanche */}
 
 [v2-network-avalanche]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/FdVwZuMV43yCb1nPmjnLQwmzS58wvKuLMPzcZ4UWgWAc
 [v2-explorer-avalanche]: https://thegraph.com/explorer/subgraphs/FdVwZuMV43yCb1nPmjnLQwmzS58wvKuLMPzcZ4UWgWAc
-[v2-studio-avalanche]: https://api.studio.thegraph.com/query/112500/sablier-v2-avalanche/version/latest
+[v2-studio-avalanche]: https://api.studio.thegraph.com/query/57079/sablier-v2-avalanche/version/latest
 
 {/* Chain: Base */}
 
 [v2-network-base]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/3pxjsW9rbDjmZpoQWzc5CAo4vzcyYE9YQyTghntmnb1K
 [v2-explorer-base]: https://thegraph.com/explorer/subgraphs/3pxjsW9rbDjmZpoQWzc5CAo4vzcyYE9YQyTghntmnb1K
-[v2-studio-base]: https://api.studio.thegraph.com/query/112500/sablier-v2-base/version/latest
+[v2-studio-base]: https://api.studio.thegraph.com/query/57079/sablier-v2-base/version/latest
 
 {/* Chain: Blast */}
 
 [v2-network-blast]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/BXoC2ToMZXnTmCjWftQRPh9zMyM7ysijMN54Nxzb2CEY
 [v2-explorer-blast]: https://thegraph.com/explorer/subgraphs/BXoC2ToMZXnTmCjWftQRPh9zMyM7ysijMN54Nxzb2CEY
-[v2-studio-blast]: https://api.studio.thegraph.com/query/112500/sablier-v2-blast/version/latest
+[v2-studio-blast]: https://api.studio.thegraph.com/query/57079/sablier-v2-blast/version/latest
 
 {/* Chain: BSC */}
 
 [v2-network-bsc]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/BVyi15zcH5eUg5PPKfRDDesezMezh6cAkn8LPvh7MVAF
 [v2-explorer-bsc]: https://thegraph.com/explorer/subgraphs/BVyi15zcH5eUg5PPKfRDDesezMezh6cAkn8LPvh7MVAF
-[v2-studio-bsc]: https://api.studio.thegraph.com/query/112500/sablier-v2-bsc/version/latest
+[v2-studio-bsc]: https://api.studio.thegraph.com/query/57079/sablier-v2-bsc/version/latest
 
 {/* Chain: Chiliz */}
 
 [v2-network-chiliz]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/HKvzAuGjrEiza11W48waJy5csbhKpkMLF688arwHhT5f
 [v2-explorer-chiliz]: https://thegraph.com/explorer/subgraphs/HKvzAuGjrEiza11W48waJy5csbhKpkMLF688arwHhT5f
-[v2-studio-chiliz]: https://api.studio.thegraph.com/query/112500/sablier-v2-chiliz/version/latest
+[v2-studio-chiliz]: https://api.studio.thegraph.com/query/57079/sablier-v2-chiliz/version/latest
 
 {/* Chain: Gnosis */}
 
 [v2-network-gnosis]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/EXhNLbhCbsewJPx4jx5tutNXpxwdgng2kmX1J7w1bFyu
 [v2-explorer-gnosis]: https://thegraph.com/explorer/subgraphs/EXhNLbhCbsewJPx4jx5tutNXpxwdgng2kmX1J7w1bFyu
-[v2-studio-gnosis]: https://api.studio.thegraph.com/query/112500/sablier-v2-gnosis/version/latest
+[v2-studio-gnosis]: https://api.studio.thegraph.com/query/57079/sablier-v2-gnosis/version/latest
 
 {/* Chain: Lightlink */}
 
@@ -87,44 +87,44 @@ import DeprecatedEndpoints from "@site/docs/snippets/DeprecatedEndpoints.mdx";
 {/* Chain: Mainnet | Ethereum */}
 
 [v2-explorer-ethereum]: https://thegraph.com/explorer/subgraphs/EuZZnhFtdCGqN2Zt7EMGYDqQKNrVuhJL63KAfwvF35bL
-[v2-studio-ethereum]: https://api.studio.thegraph.com/query/112500/sablier-v2/version/latest
+[v2-studio-ethereum]: https://api.studio.thegraph.com/query/57079/sablier-v2/version/latest
 [v2-network-ethereum]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/EuZZnhFtdCGqN2Zt7EMGYDqQKNrVuhJL63KAfwvF35bL
 
 {/* Chain: Optimism */}
 
 [v2-network-optimism]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/6e6Dvs1yDpsWDDREZRqxGi54SVdvTNzUdKpKJxniKVrp
 [v2-explorer-optimism]: https://thegraph.com/explorer/subgraphs/6e6Dvs1yDpsWDDREZRqxGi54SVdvTNzUdKpKJxniKVrp
-[v2-studio-optimism]: https://api.studio.thegraph.com/query/112500/sablier-v2-optimism/version/latest
+[v2-studio-optimism]: https://api.studio.thegraph.com/query/57079/sablier-v2-optimism/version/latest
 
 {/* Chain: Optimism Sepolia */}
 
 [v2-network-optimism-sepolia]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/2a2JpbmBfQs78UEvQYXgweHetcZUPm9zXCjP69o5mTed
 [v2-explorer-optimism-sepolia]: https://thegraph.com/explorer/subgraphs/2a2JpbmBfQs78UEvQYXgweHetcZUPm9zXCjP69o5mTed
-[v2-studio-optimism-sepolia]: https://api.studio.thegraph.com/query/112500/sablier-v2-optimism-sepolia/version/latest
+[v2-studio-optimism-sepolia]: https://api.studio.thegraph.com/query/57079/sablier-v2-optimism-sepolia/version/latest
 
 {/* Chain: Polygon */}
 
 [v2-network-polygon]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/CsDNYv9XPUMP8vufuwDVKQrVhsxhzzRHezjLFFKZZbrx
 [v2-explorer-polygon]: https://thegraph.com/explorer/subgraphs/CsDNYv9XPUMP8vufuwDVKQrVhsxhzzRHezjLFFKZZbrx
-[v2-studio-polygon]: https://api.studio.thegraph.com/query/112500/sablier-v2-polygon/version/latest
+[v2-studio-polygon]: https://api.studio.thegraph.com/query/57079/sablier-v2-polygon/version/latest
 
 {/* Chain: Scroll */}
 
 [v2-network-scroll]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/HVcngokCByfveLwguuafrBC34xB65Ne6tpGrXHmqDSrh
 [v2-explorer-scroll]: https://thegraph.com/explorer/subgraphs/HVcngokCByfveLwguuafrBC34xB65Ne6tpGrXHmqDSrh
-[v2-studio-scroll]: https://api.studio.thegraph.com/query/112500/sablier-v2-scroll/version/latest
+[v2-studio-scroll]: https://api.studio.thegraph.com/query/57079/sablier-v2-scroll/version/latest
 
 {/* Chain: Ethereum Sepolia */}
 
 [v2-network-sepolia]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/3JR9ixhdUxX5oc2Yjr6jkG4XUqDd4guy8niL6AYzDKss
 [v2-explorer-sepolia]: https://thegraph.com/explorer/subgraphs/3JR9ixhdUxX5oc2Yjr6jkG4XUqDd4guy8niL6AYzDKss
-[v2-studio-sepolia]: https://api.studio.thegraph.com/query/112500/sablier-v2-sepolia/version/latest
+[v2-studio-sepolia]: https://api.studio.thegraph.com/query/57079/sablier-v2-sepolia/version/latest
 
 {/* Chain: zkSync */}
 
 [v2-network-zksync]: https://gateway-arbitrum.network.thegraph.com/api/API_KEY/subgraphs/id/GY2fGozmfZiZ3xF2MfevohLR4YGnyxGxAyxzi9zmU5bY
 [v2-explorer-zksync]: https://thegraph.com/explorer/subgraphs/GY2fGozmfZiZ3xF2MfevohLR4YGnyxGxAyxzi9zmU5bY
-[v2-studio-zksync]: https://api.studio.thegraph.com/query/112500/sablier-v2-zksync/version/latest
+[v2-studio-zksync]: https://api.studio.thegraph.com/query/57079/sablier-v2-zksync/version/latest
 
 {/* --------------------------------------------------------------------------------------------------------------------------------- */}
 


### PR DESCRIPTION
The old endpoints are still hosted on the historical Subgraph Studio account