### PR TITLE
fix: correct hyperlink for admins

### DIFF
--- a/src/components/organisms/AdminsTable.tsx
+++ b/src/components/organisms/AdminsTable.tsx
@@ -96,7 +96,8 @@ export function AdminsTable() {
     content += "| :---- | :------ |\n";
 
     for (const admin of admins) {
-      const addressLink = `[${admin.adminAddress}](${admin.explorerUrl}})`;
+      const explorerBaseUrl = admin.explorerUrl?.replace(/\/address\/.*$/, "") || "";
+      const addressLink = `[${admin.adminAddress}](${explorerBaseUrl}/address/${admin.adminAddress})`;
       content += `| ${admin.chainName} | ${addressLink} |\n`;
     }
 


### PR DESCRIPTION
Currently, the [admin URL links](https://docs.sablier.com/concepts/governance#admins) point to the `SablierLockup` contract instead of the admin address. For example, this:

<img width="700" height="400" alt="image" src="https://github.com/user-attachments/assets/939656fe-a9d4-447a-8dec-708b35632209" />

points to: https://abscan.org/address/0x14Eb4AB47B2ec2a71763eaBa202a252E176FAE88%7D

(also incorrect `%7D`)

---

Also, I noticed that because we’re retrieving the address on-chain, it takes a couple of seconds to load and shows this:

<img width="360" height="294" alt="image" src="https://github.com/user-attachments/assets/4423595a-e7de-426b-81ad-827e07243b45" />

Wouldn't it be better to declare them in a simple table?